### PR TITLE
[ZF3] [BC-BREAK] Remove ServiceLocatorAwareInterface from AbstractController

### DIFF
--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -46,8 +46,7 @@ use Zend\Stdlib\ResponseInterface as Response;
 abstract class AbstractController implements
     Dispatchable,
     EventManagerAwareInterface,
-    InjectApplicationEventInterface,
-    ServiceLocatorAwareInterface
+    InjectApplicationEventInterface
 {
     /**
      * @var PluginManager
@@ -73,11 +72,6 @@ abstract class AbstractController implements
      * @var EventManagerInterface
      */
     protected $events;
-
-    /**
-     * @var ServiceLocatorInterface
-     */
-    protected $serviceLocator;
 
     /**
      * @var null|string|string[]
@@ -228,27 +222,6 @@ abstract class AbstractController implements
         }
 
         return $this->event;
-    }
-
-    /**
-     * Set serviceManager instance
-     *
-     * @param  ServiceLocatorInterface $serviceLocator
-     * @return void
-     */
-    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
-    {
-        $this->serviceLocator = $serviceLocator;
-    }
-
-    /**
-     * Retrieve serviceManager instance
-     *
-     * @return ServiceLocatorInterface
-     */
-    public function getServiceLocator()
-    {
-        return $this->serviceLocator;
     }
 
     /**

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -17,8 +17,6 @@ use Zend\Http\PhpEnvironment\Response as HttpResponse;
 use Zend\Http\Request as HttpRequest;
 use Zend\Mvc\InjectApplicationEventInterface;
 use Zend\Mvc\MvcEvent;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\DispatchableInterface as Dispatchable;
 use Zend\Stdlib\RequestInterface as Request;
 use Zend\Stdlib\ResponseInterface as Response;

--- a/test/Controller/AbstractControllerTest.php
+++ b/test/Controller/AbstractControllerTest.php
@@ -99,8 +99,7 @@ class AbstractControllerTest extends TestCase
             ->with($this->logicalAnd(
                 $this->contains('Zend\\EventManager\\EventManagerAwareInterface'),
                 $this->contains('Zend\\Stdlib\\DispatchableInterface'),
-                $this->contains('Zend\\Mvc\\InjectApplicationEventInterface'),
-                $this->contains('Zend\\ServiceManager\\ServiceLocatorAwareInterface')
+                $this->contains('Zend\\Mvc\\InjectApplicationEventInterface')
             ));
 
         $this->controller->setEventManager($eventManager);

--- a/test/Controller/ActionControllerTest.php
+++ b/test/Controller/ActionControllerTest.php
@@ -161,11 +161,6 @@ class ActionControllerTest extends TestCase
         $this->assertSame($this->event, $event);
     }
 
-    public function testControllerIsLocatorAware()
-    {
-        $this->assertInstanceOf('Zend\ServiceManager\ServiceLocatorAwareInterface', $this->controller);
-    }
-
     public function testControllerIsEventAware()
     {
         $this->assertInstanceOf('Zend\Mvc\InjectApplicationEventInterface', $this->controller);

--- a/test/Controller/ControllerManagerTest.php
+++ b/test/Controller/ControllerManagerTest.php
@@ -43,7 +43,6 @@ class ControllerManagerTest extends TestCase
     {
         $controller = new TestAsset\SampleController();
         $this->controllers->injectControllerDependencies($controller, $this->controllers);
-        $this->assertSame($this->services, $controller->getServiceLocator());
         $this->assertSame($this->plugins, $controller->getPluginManager());
 
         // The default AbstractController implementation lazy instantiates an EM

--- a/test/Controller/Plugin/ForwardTest.php
+++ b/test/Controller/Plugin/ForwardTest.php
@@ -98,7 +98,6 @@ class ForwardTest extends TestCase
 
         $this->controller = new SampleController();
         $this->controller->setEvent($event);
-        $this->controller->setServiceLocator($services);
         $this->controller->setPluginManager($plugins);
 
         $this->plugin = $this->controller->plugin('forward');
@@ -127,7 +126,7 @@ class ForwardTest extends TestCase
 
     public function testDispatchRaisesDomainExceptionIfDiscoveredControllerIsNotDispatchable()
     {
-        $locator = $this->controller->getServiceLocator();
+        $locator = $this->plugins->getServiceLocator();
         $locator->add('bogus', function () {
             return new stdClass;
         });

--- a/test/Controller/RestfulControllerTest.php
+++ b/test/Controller/RestfulControllerTest.php
@@ -342,11 +342,6 @@ class RestfulControllerTest extends TestCase
         $this->assertSame($this->event, $event);
     }
 
-    public function testControllerIsLocatorAware()
-    {
-        $this->assertInstanceOf('Zend\ServiceManager\ServiceLocatorAwareInterface', $this->controller);
-    }
-
     public function testControllerIsEventAware()
     {
         $this->assertInstanceOf('Zend\Mvc\InjectApplicationEventInterface', $this->controller);

--- a/test/Controller/TestAsset/ServiceLocatorAwareController.php
+++ b/test/Controller/TestAsset/ServiceLocatorAwareController.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @author Stefano Torresi (http://stefanotorresi.it)
+ * @license See the file LICENSE.txt for copying permission.
+ * ************************************************
+ */
+
+namespace ZendTest\Mvc\Controller\TestAsset;
+
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+class ServiceLocatorAwareController extends SampleController implements ServiceLocatorAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+}

--- a/test/Service/ControllerLoaderFactoryTest.php
+++ b/test/Service/ControllerLoaderFactoryTest.php
@@ -90,7 +90,6 @@ class ControllerLoaderFactoryTest extends TestCase
 
         $controller = $this->loader->get('ZendTest\Dispatchable');
         $this->assertInstanceOf('ZendTest\Mvc\Service\TestAsset\Dispatchable', $controller);
-        $this->assertSame($this->services, $controller->getServiceLocator());
         $this->assertSame($this->services->get('EventManager'), $controller->getEventManager());
         $this->assertSame($this->services->get('ControllerPluginManager'), $controller->getPluginManager());
     }


### PR DESCRIPTION
As discussed in zendframework/zf2#5168.

Mantaining BC is actually as easy as implementing `ServiceLocatorAwareInterface` explicitly and importing `ServiceLocatorAwareTrait` into userland controller classes.

This is just one little step towards zendframework/zf2#6068.
