### PR TITLE
Hops not used because of unset in get method.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ install:
 
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
-  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit --verbose ; fi
-  - ./vendor/bin/php-cs-fixer fix -v
+  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit ; fi
+  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run ; fi
 
 after_script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
 
 script:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml --verbose ; fi
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit ; fi
   - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit --verbose ; fi
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run ; fi
+  - ./vendor/bin/php-cs-fixer fix -v
 
 after_script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs
 
 script:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml --verbose ; fi
-  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit --verbose ; fi
   - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run ; fi
 
 after_script:

--- a/src/Controller/Plugin/FlashMessenger.php
+++ b/src/Controller/Plugin/FlashMessenger.php
@@ -655,9 +655,5 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
             $this->messages[$namespace] = $messages;
             $namespaces[] = $namespace;
         }
-
-        foreach ($namespaces as $namespace) {
-            unset($container->{$namespace});
-        }
     }
 }

--- a/src/Controller/Plugin/FlashMessenger.php
+++ b/src/Controller/Plugin/FlashMessenger.php
@@ -388,7 +388,10 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
      */
     public function clearMessagesFromContainer()
     {
-        $this->getMessagesFromContainer();
+        foreach ($namespaces as $namespace) {
+            unset($container->{$namespace});
+        }
+        
         if (empty($this->messages)) {
             return false;
         }

--- a/src/Controller/Plugin/FlashMessenger.php
+++ b/src/Controller/Plugin/FlashMessenger.php
@@ -388,6 +388,13 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
      */
     public function clearMessagesFromContainer()
     {
+        $container = $this->getContainer();
+        
+        $namespaces = [];
+        foreach ($container as $namespace => $messages) {
+            $namespaces[] = $namespace;
+        }
+        
         foreach ($namespaces as $namespace) {
             unset($container->{$namespace});
         }
@@ -653,10 +660,8 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
 
         $container = $this->getContainer();
 
-        $namespaces = [];
         foreach ($container as $namespace => $messages) {
             $this->messages[$namespace] = $messages;
-            $namespaces[] = $namespace;
         }
     }
 }


### PR DESCRIPTION
Calling getMessagesFromContainer() results in clearing the messages in the session, regarding the hops, defined when adding a message.
