### PR TITLE
Added factory method in TranslatorAwareTreeRouteStack for missing option injection

### DIFF
--- a/src/Router/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Router/Http/TranslatorAwareTreeRouteStack.php
@@ -47,7 +47,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * @param  array|Traversable $options
      * @return TranslatorAwareTreeRouteStack
      */
-    public static function factory($options = array())
+    public static function factory($options = [])
     {
         $instance = parent::factory($options);
 

--- a/src/Router/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Router/Http/TranslatorAwareTreeRouteStack.php
@@ -41,6 +41,25 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
     protected $translatorTextDomain = 'default';
 
     /**
+     * factory(): defined by RouteInterface interface.
+     *
+     * @see    \Zend\Mvc\Router\RouteInterface::factory()
+     * @param  array|Traversable $options
+     * @return TranslatorAwareTreeRouteStack
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function factory($options = array())
+    {
+        $instance = parent::factory($options);
+
+        if (isset($options['text_domain'])) {
+            $instance->setTranslatorTextDomain($options['text_domain']);
+        }
+
+        return $instance;
+    }
+
+    /**
      * match(): defined by \Zend\Mvc\Router\RouteInterface
      *
      * @see    \Zend\Mvc\Router\RouteInterface::match()

--- a/src/Router/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Router/Http/TranslatorAwareTreeRouteStack.php
@@ -46,7 +46,6 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * @see    \Zend\Mvc\Router\RouteInterface::factory()
      * @param  array|Traversable $options
      * @return TranslatorAwareTreeRouteStack
-     * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = array())
     {

--- a/test/Router/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Router/Http/TranslatorAwareTreeRouteStackTest.php
@@ -63,9 +63,9 @@ class TranslatorAwareTreeRouteStackTest extends TestCase
         $this->assertInstanceOf('Zend\Mvc\Router\Http\TranslatorAwareTreeRouteStack', $instance);
 
         // With 'text_domain' option
-        $instance = TranslatorAwareTreeRouteStack::factory(array(
+        $instance = TranslatorAwareTreeRouteStack::factory([
             'text_domain' => 'test'
-        ));
+        ]);
         $this->assertInstanceOf('Zend\Mvc\Router\Http\TranslatorAwareTreeRouteStack', $instance);
         $this->assertEquals("test", $instance->getTranslatorTextDomain());
     }

--- a/test/Router/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Router/Http/TranslatorAwareTreeRouteStackTest.php
@@ -56,6 +56,20 @@ class TranslatorAwareTreeRouteStackTest extends TestCase
         );
     }
 
+    public function testFactory()
+    {
+        // Defaults
+        $instance = TranslatorAwareTreeRouteStack::factory();
+        $this->assertInstanceOf('Zend\Mvc\Router\Http\TranslatorAwareTreeRouteStack', $instance);
+
+        // With 'text_domain' option
+        $instance = TranslatorAwareTreeRouteStack::factory(array(
+            'text_domain' => 'test'
+        ));
+        $this->assertInstanceOf('Zend\Mvc\Router\Http\TranslatorAwareTreeRouteStack', $instance);
+        $this->assertEquals("test", $instance->getTranslatorTextDomain());
+    }
+
     public function testTranslatorAwareInterfaceImplementation()
     {
         $stack = new TranslatorAwareTreeRouteStack();


### PR DESCRIPTION
Overrided the class factory method to import option 'text_domain' using the already present setter setTranslatorTextDomain().

This is necessary to be able to instantiate the TranslatorAwareTreeRouteStack router from config with the option:

```
<?php
return array(
    'router' => array(
        'router_class' => 'Zend\Mvc\Router\Http\TranslatorAwareTreeRouteStack',
        'text_domain' => 'router',
        'routes' => array(...),
    ),

    ///
);
```

Both tests and php-cs-fixer ran ok.
