### PR TITLE
zend-stdlib is already required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
         "zendframework/zend-modulemanager": "Zend\\ModuleManager component",
         "zendframework/zend-serializer": "Zend\\Serializer component",
         "zendframework/zend-session": "Zend\\Session component for FlashMessenger, PRG, and FPRG plugins",
-        "zendframework/zend-stdlib": "Zend\\Stdlib component",
         "zendframework/zend-text": "Zend\\Text component",
         "zendframework/zend-uri": "Zend\\Uri component",
         "zendframework/zend-validator": "Zend\\Validator component",


### PR DESCRIPTION
It is insane to have in required and suggested same package.
