### PR TITLE
Correction on dispatch AbstractController

### DIFF
--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -113,8 +113,8 @@ abstract class AbstractController implements
           ->setResponse($response)
           ->setTarget($this);
 
-        $result = $this->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH, $e, function ($test) {
-            return ($test instanceof Response);
+        $result = $this->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH, $e, function ($response) {
+            return ($response instanceof Response);
         });
 
         if ($result->stopped()) {


### PR DESCRIPTION
dispatch used an uninstancied variable. Replaced $stest by $response but I think the test "return ($response instanceof Response)" is not necessary because $response is typed in method parameters.
