### PR TITLE
Unittests failing

### DIFF
--- a/test/Controller/Plugin/FilePostRedirectGetTest.php
+++ b/test/Controller/Plugin/FilePostRedirectGetTest.php
@@ -402,6 +402,14 @@ class FilePostRedirectGetTest extends TestCase
 
         $messages = $form->getMessages();
         $this->assertTrue(isset($messages['collection'][1]['text'][NotEmpty::IS_EMPTY]));
-        $this->assertTrue(isset($messages['collection'][1]['file'][NotEmpty::IS_EMPTY]));
+
+        $requiredFound = false;
+        foreach ($messages['collection'][1]['file'] as $message) {
+            if (strpos($message, 'Value is required') === 0) {
+                $requiredFound = true;
+                break;
+            }
+        }
+        $this->assertTrue($requiredFound, '"Required" message was not found in validation failure messages');
     }
 }


### PR DESCRIPTION
I just cloned this repo and unittests fails for both master and 2.5:

```
1) ZendTest\Mvc\Controller\Plugin\FilePostRedirectGetTest::testCorrectInputDataMerging
Failed asserting that false is true.

... zend-mvc/test/Controller/Plugin/FilePostRedirectGetTest.php:405
```
