### PR TITLE
Fix 'Call to a member function hasChildren() on boolean'

### DIFF
--- a/src/View/Console/DefaultRenderingStrategy.php
+++ b/src/View/Console/DefaultRenderingStrategy.php
@@ -15,6 +15,7 @@ use Zend\EventManager\EventManagerInterface;
 use Zend\Mvc\MvcEvent;
 use Zend\Stdlib\ResponseInterface as Response;
 use Zend\View\Model\ConsoleModel as ConsoleViewModel;
+use Zend\View\Model\ModelInterface;
 
 class DefaultRenderingStrategy extends AbstractListenerAggregate
 {
@@ -42,7 +43,7 @@ class DefaultRenderingStrategy extends AbstractListenerAggregate
         // marshal arguments
         $response  = $e->getResponse();
 
-        if (empty($result)) {
+        if (empty($result) || !($result instanceof ModelInterface)) {
             // There is absolutely no result, so there's nothing to display.
             // We will return an empty response object
             return $response;

--- a/test/View/Console/DefaultRenderingStrategyTest.php
+++ b/test/View/Console/DefaultRenderingStrategyTest.php
@@ -90,4 +90,35 @@ class DefaultRenderingStrategyTest extends TestCase
         $content = $response->getContent();
         $this->assertNotContains('Page not found', $content);
     }
+
+    public function testIgnoresNonModel()
+    {
+        $console = $this->getMock('Zend\Console\Adapter\AbstractAdapter');
+        $console
+            ->expects($this->any())
+            ->method('encodeText')
+            ->willReturnArgument(0)
+        ;
+
+        //Register console service
+        $sm = new ServiceManager();
+        $sm->setService('console', $console);
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Zend\Mvc\ApplicationInterface $mockApplication */
+        $mockApplication = $this->getMock('Zend\Mvc\ApplicationInterface');
+        $mockApplication
+            ->expects($this->any())
+            ->method('getServiceManager')
+            ->willReturn($sm)
+        ;
+
+        $event    = new MvcEvent();
+        $event->setApplication($mockApplication);
+
+        $model    = true;
+        $response = new Response();
+        $event->setResult($model);
+        $event->setResponse($response);
+        $this->assertSame($response, $this->strategy->render($event));
+    }
 }


### PR DESCRIPTION
- This seems to occur when the DefaultRenderingStrategy tries to render
  a result that is not an instance of Zend\View\Model\ModelInterface, in
  my case the result was a boolean true.
- I'm checking for ModelInterface rather than ConsoleModel as the render
  method seems to work with any ModelInterface, not just ConsoleModel
