### PR TITLE
Update stdlib version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "zendframework/zend-eventmanager": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-form": "~2.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-stdlib": ">=2.5.0,<2.7.0"
     },
     "require-dev": {
         "zendframework/zend-authentication": "~2.5",


### PR DESCRIPTION
- To < 2.7.0, to ensure only hydrators implementing the stdlib hydrator
  interfaces will work.
