### PR TITLE
Update to use zend-hydrator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,9 @@
         "php": ">=5.5",
         "zendframework/zend-eventmanager": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
-        "zendframework/zend-form": "~2.5",
-        "zendframework/zend-stdlib": ">=2.5.0,<2.7.0"
+        "zendframework/zend-hydrator": "~1.0",
+        "zendframework/zend-form": "~2.6",
+        "zendframework/zend-stdlib": "~2.7"
     },
     "require-dev": {
         "zendframework/zend-authentication": "~2.5",
@@ -30,7 +31,7 @@
         "zendframework/zend-inputfilter": "~2.5",
         "zendframework/zend-json": "~2.5",
         "zendframework/zend-log": "~2.5",
-        "zendframework/zend-modulemanager": "~2.5",
+        "zendframework/zend-modulemanager": "~2.6",
         "zendframework/zend-session": "~2.5",
         "zendframework/zend-serializer": "~2.5",
         "zendframework/zend-text": "~2.5",

--- a/src/Service/HydratorManagerFactory.php
+++ b/src/Service/HydratorManagerFactory.php
@@ -11,5 +11,5 @@ namespace Zend\Mvc\Service;
 
 class HydratorManagerFactory extends AbstractPluginManagerFactory
 {
-    const PLUGIN_MANAGER_CLASS = 'Zend\Stdlib\Hydrator\HydratorPluginManager';
+    const PLUGIN_MANAGER_CLASS = 'Zend\Hydrator\HydratorPluginManager';
 }

--- a/test/Service/TestAsset/CustomForm.php
+++ b/test/Service/TestAsset/CustomForm.php
@@ -10,7 +10,7 @@
 namespace ZendTest\Mvc\Service\TestAsset;
 
 use Zend\Form\Form;
-use Zend\Stdlib\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
 
 class CustomForm extends Form
 {


### PR DESCRIPTION
This patch updates the develop branch (future 2.6.0) to use zend-hydrator for hydrator functionality. This is backwards compatible, as all zend-stdlib hydrators will fulfill the same interfaces, but provides forwards compatibility with hydrators written using the zend-hydrator interfaces.
