### PR TITLE
Refactored to use upcoming EventManager v3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/doc export-ignore
 /test export-ignore
 /vendor export-ignore
 .coveralls.yml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .*.sw*
 .*.un~
 nbproject
+doc/html/
 tmp/
 
 clover.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.7.0 - TBD
+## 3.0.0 - TBD
 
 ### Added
 
-- Nothing.
+- [#31](https://github.com/zendframework/zend-mvc/pull/31) adds three required
+  arguments to the `Zend\Mvc\Application` constructor: an EventManager
+  instance, a Request instance, and a Response instance.
 
 ### Deprecated
 
@@ -17,6 +19,9 @@ All notable changes to this project will be documented in this file, in reverse 
 - Nothing.
 
 ### Fixed
+
+- [#31](https://github.com/zendframework/zend-mvc/pull/31) updates the component
+  to use zend-eventmanager v3.
 
 ## 2.6.1 - TBD
 

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.6-dev",
-            "dev-develop": "2.7-dev"
+            "dev-develop": "3.0-dev"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-eventmanager": "~2.5",
+        "zendframework/zend-eventmanager": "dev-develop as 2.7.0",
         "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-hydrator": "~1.0",
         "zendframework/zend-form": "~2.6",
-        "zendframework/zend-stdlib": "~2.7"
+        "zendframework/zend-stdlib": "~2.7",
+        "container-interop/container-interop": "^1.1"
     },
     "require-dev": {
         "zendframework/zend-authentication": "~2.5",
@@ -31,14 +32,14 @@
         "zendframework/zend-inputfilter": "~2.5",
         "zendframework/zend-json": "~2.5",
         "zendframework/zend-log": "~2.5",
-        "zendframework/zend-modulemanager": "~2.6",
+        "zendframework/zend-modulemanager": "dev-develop as 2.7.0",
         "zendframework/zend-session": "~2.5",
         "zendframework/zend-serializer": "~2.5",
         "zendframework/zend-text": "~2.5",
         "zendframework/zend-uri": "~2.5",
         "zendframework/zend-validator": "~2.5",
         "zendframework/zend-version": "~2.5",
-        "zendframework/zend-view": "~2.5",
+        "zendframework/zend-view": "dev-develop as 2.6.0",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/doc/book/migration.md
+++ b/doc/book/migration.md
@@ -1,0 +1,69 @@
+# Migration Guide
+
+This is a guide for migration from version 2 to version 3 of zend-mvc.
+
+## Application
+
+The constructor signature of `Zend\Mvc\Application` has changed. Previously, it
+was:
+
+```php
+__construct($configuration, ServiceManager $serviceManager)
+```
+
+and internally, it pulled the services `EventManager`, `Request`, and `Response`
+from the provided `$serviceManager` during initialization.
+
+The new constructor signature is:
+
+```php
+__construct(
+    $configuration,
+    ServiceManager $serviceManager,
+    EventManager $events,
+    RequestInterface $request,
+    ResponseInterface $response
+)
+```
+
+making all dependencies explicit. The factory
+`Zend\Mvc\Service\ApplicationFactory` was updated to follow the new signature.
+
+This change should only affect users who are manually instantiating the
+`Application` instance.
+
+## EventManager initializer and ControllerManager event manager injection
+
+zend-mvc provides two mechanisms for injecting event managers into
+`EventManagerAware` objects. One is the "EventManagerAwareInitializer"
+registered in `Zend\Mvc\Service\ServiceManagerConfig`, and the other is internal
+logic in `Zend\Mvc\Controller\ControllerManager`. In both cases, the logic was
+updated due to changes in the v3 version of zend-eventmanager. 
+
+Previously each would check if the instance's `getEventManager()` method
+returned an event manager instance, and, if so, inject the shared event manager:
+
+```php
+$events = $instance->getEventManager();
+if ($events instanceof EventManagerInterface) {
+    $events->setSharedManager($container->get('SharedEventManager'));
+}
+```
+
+In zend-eventmanager v3, event manager's are now injected with the shared
+manager at instantiation, and no setter exists for providing the shared manager.
+As such, the above logic changed to:
+
+```php
+$events = $instance->getEventManager();
+if (! $events || ! $events->getSharedManager()) {
+    $instance->setEventManager($container->get('EventManager'));
+}
+```
+
+In other words, it re-injects with a new event manager instance if the instance
+pulled does not have a shared manager composed.
+
+This likely will not cause regressions in existing code, but may be something to
+be aware of if you were previously depending on lazy-loaded event manager
+state.

--- a/doc/bookdown.json
+++ b/doc/bookdown.json
@@ -1,0 +1,8 @@
+{
+  "title": "zend-mvc: MVC application provider",
+  "content": [
+    {"Intro": "../README.md"},
+    {"Migration Guide": "book/migration.md"}
+  ],
+  "target": "./html"
+}

--- a/src/Application.php
+++ b/src/Application.php
@@ -365,6 +365,7 @@ class Application implements
 
         $event->setName(MvcEvent::EVENT_FINISH);
         $events->triggerEvent($event);
+
         return $this;
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -12,6 +12,7 @@ namespace Zend\Mvc;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\ServiceManager\ServiceManager;
+use Zend\Stdlib\RequestInterface;
 use Zend\Stdlib\ResponseInterface;
 
 /**
@@ -103,15 +104,18 @@ class Application implements
      * @param mixed $configuration
      * @param ServiceManager $serviceManager
      */
-    public function __construct($configuration, ServiceManager $serviceManager)
-    {
+    public function __construct(
+        $configuration,
+        ServiceManager $serviceManager,
+        EventManagerInterface $events,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
         $this->configuration  = $configuration;
         $this->serviceManager = $serviceManager;
-
-        $this->setEventManager($serviceManager->get('EventManager'));
-
-        $this->request        = $serviceManager->get('Request');
-        $this->response       = $serviceManager->get('Response');
+        $this->setEventManager($events);
+        $this->request        = $request;
+        $this->response       = $response;
     }
 
     /**
@@ -142,19 +146,20 @@ class Application implements
         $listeners = array_unique(array_merge($this->defaultListeners, $listeners));
 
         foreach ($listeners as $listener) {
-            $events->attach($serviceManager->get($listener));
+            $serviceManager->get($listener)->attach($events);
         }
 
         // Setup MVC Event
         $this->event = $event  = new MvcEvent();
+        $event->setName(MvcEvent::EVENT_BOOTSTRAP);
         $event->setTarget($this);
-        $event->setApplication($this)
-              ->setRequest($this->request)
-              ->setResponse($this->response)
-              ->setRouter($serviceManager->get('Router'));
+        $event->setApplication($this);
+        $event->setRequest($this->request);
+        $event->setResponse($this->response);
+        $event->setRouter($serviceManager->get('Router'));
 
         // Trigger bootstrap events
-        $events->trigger(MvcEvent::EVENT_BOOTSTRAP, $event);
+        $events->triggerEvent($event);
         return $this;
     }
 
@@ -294,13 +299,15 @@ class Application implements
         };
 
         // Trigger route event
-        $result = $events->trigger(MvcEvent::EVENT_ROUTE, $event, $shortCircuit);
+        $event->setName(MvcEvent::EVENT_ROUTE);
+        $result = $events->triggerEventUntil($shortCircuit, $event);
         if ($result->stopped()) {
             $response = $result->last();
             if ($response instanceof ResponseInterface) {
+                $event->setName(MvcEvent::EVENT_FINISH);
                 $event->setTarget($this);
                 $event->setResponse($response);
-                $events->trigger(MvcEvent::EVENT_FINISH, $event);
+                $events->triggerEvent($event);
                 $this->response = $response;
                 return $this;
             }
@@ -311,14 +318,16 @@ class Application implements
         }
 
         // Trigger dispatch event
-        $result = $events->trigger(MvcEvent::EVENT_DISPATCH, $event, $shortCircuit);
+        $event->setName(MvcEvent::EVENT_DISPATCH);
+        $result = $events->triggerEventUntil($shortCircuit, $event);
 
         // Complete response
         $response = $result->last();
         if ($response instanceof ResponseInterface) {
+            $event->setName(MvcEvent::EVENT_FINISH);
             $event->setTarget($this);
             $event->setResponse($response);
-            $events->trigger(MvcEvent::EVENT_FINISH, $event);
+            $events->triggerEvent($event);
             $this->response = $response;
             return $this;
         }
@@ -350,8 +359,12 @@ class Application implements
     {
         $events = $this->events;
         $event->setTarget($this);
-        $events->trigger(MvcEvent::EVENT_RENDER, $event);
-        $events->trigger(MvcEvent::EVENT_FINISH, $event);
+
+        $event->setName(MvcEvent::EVENT_RENDER);
+        $events->triggerEvent($event);
+
+        $event->setName(MvcEvent::EVENT_FINISH);
+        $events->triggerEvent($event);
         return $this;
     }
 }

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -109,13 +109,14 @@ abstract class AbstractController implements
         $this->response = $response;
 
         $e = $this->getEvent();
-        $e->setRequest($request)
-          ->setResponse($response)
-          ->setTarget($this);
+        $e->setName(MvcEvent::EVENT_DISPATCH);
+        $e->setRequest($request);
+        $e->setResponse($response);
+        $e->setTarget($this);
 
-        $result = $this->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH, $e, function ($test) {
+        $result = $this->getEventManager()->triggerEventUntil(function ($test) {
             return ($test instanceof Response);
-        });
+        }, $e);
 
         if ($result->stopped()) {
             return $result->last();

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -11,6 +11,7 @@ namespace Zend\Mvc\Controller;
 
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\SharedEventManagerInterface;
 use Zend\Mvc\Exception;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ConfigInterface;
@@ -73,10 +74,10 @@ class ControllerManager extends AbstractPluginManager
             // is why the shared EM injection needs to happen; the conditional
             // will always pass.
             $events = $controller->getEventManager();
-            if (!$events instanceof EventManagerInterface) {
+            if (! $events instanceof EventManagerInterface
+                || ! $events->getSharedManager() instanceof SharedEventManagerInterface
+            ) {
                 $controller->setEventManager($parentLocator->get('EventManager'));
-            } else {
-                $events->setSharedManager($parentLocator->get('SharedEventManager'));
             }
         }
 

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -10,7 +10,6 @@
 namespace Zend\Mvc\Controller;
 
 use Zend\EventManager\EventManagerAwareInterface;
-use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\SharedEventManagerInterface;
 use Zend\Mvc\Exception;
 use Zend\ServiceManager\AbstractPluginManager;

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -74,9 +74,7 @@ class ControllerManager extends AbstractPluginManager
             // is why the shared EM injection needs to happen; the conditional
             // will always pass.
             $events = $controller->getEventManager();
-            if (! $events instanceof EventManagerInterface
-                || ! $events->getSharedManager() instanceof SharedEventManagerInterface
-            ) {
+            if (! $events || ! $events->getSharedManager() instanceof SharedEventManagerInterface) {
                 $controller->setEventManager($parentLocator->get('EventManager'));
             }
         }

--- a/src/Controller/Plugin/Forward.php
+++ b/src/Controller/Plugin/Forward.php
@@ -177,9 +177,9 @@ class Forward extends AbstractPlugin
             $results[$id] = [];
             foreach ($eventArray as $eventName => $classArray) {
                 $results[$id][$eventName] = [];
-                $events = $sharedEvents->getListeners($id, $eventName);
+                $events = $sharedEvents->getListeners([$id], $eventName);
                 foreach ($events as $currentEvent) {
-                    $currentCallback = $currentEvent->getCallback();
+                    $currentCallback = $currentEvent;
 
                     // If we have an array, grab the object
                     if (is_array($currentCallback)) {
@@ -193,7 +193,7 @@ class Forward extends AbstractPlugin
 
                     foreach ($classArray as $class) {
                         if ($currentCallback instanceof $class) {
-                            $sharedEvents->detach($id, $currentEvent);
+                            $sharedEvents->detach($currentEvent, $id);
                             $results[$id][$eventName][] = $currentEvent;
                         }
                     }

--- a/src/DispatchListener.php
+++ b/src/DispatchListener.php
@@ -99,8 +99,7 @@ class DispatchListener extends AbstractListenerAggregate
             $e->setControllerClass(get_class($controller));
             $e->setParam('exception', $ex);
 
-            $results = $events->triggerEvent($e);
-            $return  = $results->last();
+            $return = $events->triggerEvent($e)->last();
             if (! $return) {
                 $return = $e->getResult();
             }

--- a/src/DispatchListener.php
+++ b/src/DispatchListener.php
@@ -43,9 +43,10 @@ class DispatchListener extends AbstractListenerAggregate
      * Attach listeners to an event manager
      *
      * @param  EventManagerInterface $events
+     * @param  int $priority
      * @return void
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'onDispatch']);
         if (function_exists('zend_monitor_custom_event_ex')) {
@@ -92,12 +93,14 @@ class DispatchListener extends AbstractListenerAggregate
         try {
             $return = $controller->dispatch($request, $response);
         } catch (\Exception $ex) {
-            $e->setError($application::ERROR_EXCEPTION)
-                  ->setController($controllerName)
-                  ->setControllerClass(get_class($controller))
-                  ->setParam('exception', $ex);
-            $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $e);
-            $return = $results->last();
+            $e->setName(MvcEvent::EVENT_DISPATCH_ERROR);
+            $e->setError($application::ERROR_EXCEPTION);
+            $e->setController($controllerName);
+            $e->setControllerClass(get_class($controller));
+            $e->setParam('exception', $ex);
+
+            $results = $events->triggerEvent($e);
+            $return  = $results->last();
             if (! $return) {
                 $return = $e->getResult();
             }
@@ -153,15 +156,16 @@ class DispatchListener extends AbstractListenerAggregate
         Application $application,
         \Exception $exception = null
     ) {
-        $event->setError($type)
-              ->setController($controllerName)
-              ->setControllerClass('invalid controller class or alias: ' . $controllerName);
+        $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
+        $event->setError($type);
+        $event->setController($controllerName);
+        $event->setControllerClass('invalid controller class or alias: ' . $controllerName);
         if ($exception !== null) {
             $event->setParam('exception', $exception);
         }
 
         $events  = $application->getEventManager();
-        $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $event);
+        $results = $events->triggerEvent($event);
         $return  = $results->last();
         if (! $return) {
             $return = $event->getResult();
@@ -211,12 +215,13 @@ class DispatchListener extends AbstractListenerAggregate
         Application $application,
         \Exception $exception
     ) {
-        $event->setError($application::ERROR_EXCEPTION)
-              ->setController($controllerName)
-              ->setParam('exception', $exception);
+        $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
+        $event->setError($application::ERROR_EXCEPTION);
+        $event->setController($controllerName);
+        $event->setParam('exception', $exception);
 
         $events  = $application->getEventManager();
-        $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $event);
+        $results = $events->triggerEvent($event);
         $return  = $results->last();
         if (! $return) {
             return $event->getResult();

--- a/src/HttpMethodListener.php
+++ b/src/HttpMethodListener.php
@@ -53,7 +53,7 @@ class HttpMethodListener extends AbstractListenerAggregate
     /**
      * {@inheritdoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         if (! $this->isEnabled()) {
             return;

--- a/src/RouteListener.php
+++ b/src/RouteListener.php
@@ -18,9 +18,10 @@ class RouteListener extends AbstractListenerAggregate
      * Attach to an event manager
      *
      * @param  EventManagerInterface $events
+     * @param  int $priority
      * @return void
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, [$this, 'onRoute']);
     }
@@ -44,9 +45,10 @@ class RouteListener extends AbstractListenerAggregate
         $routeMatch = $router->match($request);
 
         if (!$routeMatch instanceof Router\RouteMatch) {
+            $e->setName(MvcEvent::EVENT_DISPATCH_ERROR);
             $e->setError(Application::ERROR_ROUTER_NO_MATCH);
 
-            $results = $target->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $e);
+            $results = $target->getEventManager()->triggerEvent($e);
             if (count($results)) {
                 return $results->last();
             }

--- a/src/SendResponseListener.php
+++ b/src/SendResponseListener.php
@@ -69,9 +69,10 @@ class SendResponseListener extends AbstractListenerAggregate implements
      * Attach the aggregate to the specified event manager
      *
      * @param  EventManagerInterface $events
+     * @param  int $priority
      * @return void
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_FINISH, [$this, 'sendResponse'], -10000);
     }
@@ -91,7 +92,7 @@ class SendResponseListener extends AbstractListenerAggregate implements
         $event = $this->getEvent();
         $event->setResponse($response);
         $event->setTarget($this);
-        $this->getEventManager()->trigger($event);
+        $this->getEventManager()->triggerEvent($event);
     }
 
     /**

--- a/src/Service/ApplicationFactory.php
+++ b/src/Service/ApplicationFactory.php
@@ -26,6 +26,12 @@ class ApplicationFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return new Application($serviceLocator->get('Config'), $serviceLocator);
+        return new Application(
+            $serviceLocator->get('Config'),
+            $serviceLocator,
+            $serviceLocator->get('EventManager'),
+            $serviceLocator->get('Request'),
+            $serviceLocator->get('Response')
+        );
     }
 }

--- a/src/Service/EventManagerFactory.php
+++ b/src/Service/EventManagerFactory.php
@@ -26,8 +26,9 @@ class EventManagerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $em = new EventManager();
-        $em->setSharedManager($serviceLocator->get('SharedEventManager'));
-        return $em;
+        if ($serviceLocator->has('SharedEventManager')) {
+            return new EventManager($serviceLocator->get('SharedEventManager'));
+        }
+        return new EventManager();
     }
 }

--- a/src/Service/ModuleManagerFactory.php
+++ b/src/Service/ModuleManagerFactory.php
@@ -129,8 +129,8 @@ class ModuleManagerFactory implements FactoryInterface
         );
 
         $events = $serviceLocator->get('EventManager');
-        $events->attach($defaultListeners);
-        $events->attach($serviceListener);
+        $defaultListeners->attach($events);
+        $serviceListener->attach($events);
 
         $moduleEvent = new ModuleEvent;
         $moduleEvent->setParam('ServiceManager', $serviceLocator);

--- a/src/View/Console/CreateViewModelListener.php
+++ b/src/View/Console/CreateViewModelListener.php
@@ -20,11 +20,11 @@ class CreateViewModelListener extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(Events $events)
+    public function attach(Events $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'createViewModelFromString'], -80);
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'createViewModelFromArray'],  -80);
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'createViewModelFromNull'],   -80);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'createViewModelFromArray'], -80);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'createViewModelFromNull'], -80);
     }
 
     /**

--- a/src/View/Console/DefaultRenderingStrategy.php
+++ b/src/View/Console/DefaultRenderingStrategy.php
@@ -22,7 +22,7 @@ class DefaultRenderingStrategy extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER, [$this, 'render'], -10000);
     }

--- a/src/View/Console/ExceptionStrategy.php
+++ b/src/View/Console/ExceptionStrategy.php
@@ -60,7 +60,7 @@ EOT;
     /**
      * {@inheritDoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'prepareExceptionViewModel']);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER_ERROR, [$this, 'prepareExceptionViewModel']);
@@ -220,7 +220,8 @@ EOT;
                             ':line',
                             ':stack',
                             ':previous',
-                        ], [
+                        ],
+                        [
                             get_class($exception),
                             $exception->getMessage(),
                             $exception->getCode(),
@@ -241,7 +242,8 @@ EOT;
                             ':line',
                             ':stack',
                             ':previous',
-                        ], [
+                        ],
+                        [
                             '',
                             '',
                             '',

--- a/src/View/Console/InjectNamedConsoleParamsListener.php
+++ b/src/View/Console/InjectNamedConsoleParamsListener.php
@@ -19,7 +19,7 @@ class InjectNamedConsoleParamsListener extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(Events $events)
+    public function attach(Events $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'injectNamedParams'], -80);
     }

--- a/src/View/Console/RouteNotFoundStrategy.php
+++ b/src/View/Console/RouteNotFoundStrategy.php
@@ -47,7 +47,7 @@ class RouteNotFoundStrategy extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'handleRouteNotFoundError']);
     }
@@ -244,7 +244,8 @@ class RouteNotFoundStrategy extends AbstractListenerAggregate
 
                 // We prepend the usage by the module name (printed in red), so that each module is
                 // clearly visible by the user
-                $moduleName = sprintf("%s\n%s\n%s\n",
+                $moduleName = sprintf(
+                    "%s\n%s\n%s\n",
                     str_repeat('-', $console->getWidth()),
                     $name,
                     str_repeat('-', $console->getWidth())

--- a/src/View/Console/ViewManager.php
+++ b/src/View/Console/ViewManager.php
@@ -48,11 +48,11 @@ class ViewManager extends BaseViewManager
         $this->registerMvcRenderingStrategies($events);
         $this->registerViewStrategies();
 
-        $events->attach($routeNotFoundStrategy);
-        $events->attach($exceptionStrategy);
+        $routeNotFoundStrategy->attach($events);
+        $exceptionStrategy->attach($events);
         $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$injectViewModelListener, 'injectViewModel'], -100);
         $events->attach(MvcEvent::EVENT_RENDER_ERROR, [$injectViewModelListener, 'injectViewModel'], -100);
-        $events->attach($mvcRenderingStrategy);
+        $mvcRenderingStrategy->attach($events);
 
         $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, [$injectParamsListener,  'injectNamedParams'], 1000);
         $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, [$createViewModelListener, 'createViewModelFromArray'], -80);

--- a/src/View/Http/CreateViewModelListener.php
+++ b/src/View/Http/CreateViewModelListener.php
@@ -20,10 +20,10 @@ class CreateViewModelListener extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(Events $events)
+    public function attach(Events $events, $priority = 1)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'createViewModelFromArray'],  -80);
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'createViewModelFromNull'],   -80);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'createViewModelFromArray'], -80);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'createViewModelFromNull'], -80);
     }
 
     /**

--- a/src/View/Http/DefaultRenderingStrategy.php
+++ b/src/View/Http/DefaultRenderingStrategy.php
@@ -45,7 +45,7 @@ class DefaultRenderingStrategy extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER, [$this, 'render'], -10000);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER_ERROR, [$this, 'render'], -10000);
@@ -108,9 +108,11 @@ class DefaultRenderingStrategy extends AbstractListenerAggregate
 
             $application = $e->getApplication();
             $events      = $application->getEventManager();
-            $e->setError(Application::ERROR_EXCEPTION)
-              ->setParam('exception', $ex);
-            $events->trigger(MvcEvent::EVENT_RENDER_ERROR, $e);
+
+            $e->setError(Application::ERROR_EXCEPTION);
+            $e->setParam('exception', $ex);
+            $e->setName(MvcEvent::EVENT_RENDER_ERROR);
+            $events->triggerEvent($e);
         }
 
         return $response;

--- a/src/View/Http/ExceptionStrategy.php
+++ b/src/View/Http/ExceptionStrategy.php
@@ -34,7 +34,7 @@ class ExceptionStrategy extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'prepareExceptionViewModel']);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER_ERROR, [$this, 'prepareExceptionViewModel']);

--- a/src/View/Http/InjectRoutematchParamsListener.php
+++ b/src/View/Http/InjectRoutematchParamsListener.php
@@ -27,7 +27,7 @@ class InjectRoutematchParamsListener extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'injectParams'], 90);
     }

--- a/src/View/Http/InjectTemplateListener.php
+++ b/src/View/Http/InjectTemplateListener.php
@@ -42,7 +42,7 @@ class InjectTemplateListener extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(Events $events)
+    public function attach(Events $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'injectTemplate'], -90);
     }
@@ -136,8 +136,7 @@ class InjectTemplateListener extends AbstractListenerAggregate
         }
 
         foreach ($this->controllerMap as $namespace => $replacement) {
-            if (
-                // Allow disabling rule by setting value to false since config
+            if (// Allow disabling rule by setting value to false since config
                 // merging have no feature to remove entries
                 false == $replacement
                 // Match full class or full namespace

--- a/src/View/Http/InjectViewModelListener.php
+++ b/src/View/Http/InjectViewModelListener.php
@@ -20,7 +20,7 @@ class InjectViewModelListener extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(Events $events)
+    public function attach(Events $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'injectViewModel'], -100);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'injectViewModel'], -100);

--- a/src/View/Http/RouteNotFoundStrategy.php
+++ b/src/View/Http/RouteNotFoundStrategy.php
@@ -50,7 +50,7 @@ class RouteNotFoundStrategy extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'prepareNotFoundViewModel'], -90);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'detectNotFoundError']);

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -12,8 +12,10 @@ namespace ZendTest\Mvc;
 use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionObject;
+use ReflectionProperty;
 use stdClass;
 use Zend\Http\PhpEnvironment\Response;
+use Zend\ModuleManager\Listener\ConfigListener;
 use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router;
@@ -21,9 +23,12 @@ use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\Mvc\Service\ServiceListenerFactory;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\ArrayUtils;
+use Zend\Stdlib\ResponseInterface;
 
 class ApplicationTest extends TestCase
 {
+    use EventManagerIntrospectionTrait;
+
     /**
      * @var ServiceManager
      */
@@ -69,15 +74,13 @@ class ApplicationTest extends TestCase
 
     public function getConfigListener()
     {
-        $manager   = $this->serviceManager->get('ModuleManager');
-        $listeners = $manager->getEventManager()->getListeners('loadModule');
-        foreach ($listeners as $listener) {
-            $callback = $listener->getCallback();
-            if (!is_array($callback)) {
+        $manager = $this->serviceManager->get('ModuleManager');
+        foreach ($this->getListenersForEvent('loadModule', $manager->getEventManager()) as $listener) {
+            if (! is_array($listener)) {
                 continue;
             }
-            $object = array_shift($callback);
-            if (!$object instanceof \Zend\ModuleManager\Listener\ConfigListener) {
+            $object = array_shift($listener);
+            if (! $object instanceof ConfigListener) {
                 continue;
             }
             return $object;
@@ -129,7 +132,7 @@ class ApplicationTest extends TestCase
     public function testEventsAreEmptyAtFirst()
     {
         $events = $this->application->getEventManager();
-        $registeredEvents = $events->getEvents();
+        $registeredEvents = $this->getEventsFromEventManager($events);
         $this->assertEquals([], $registeredEvents);
 
         $sharedEvents = $events->getSharedManager();
@@ -148,12 +151,10 @@ class ApplicationTest extends TestCase
         $listenerService = $this->serviceManager->get($listenerServiceName);
         $this->application->bootstrap($isCustom ? (array) $listenerServiceName : []);
         $events = $this->application->getEventManager();
-        $listeners = $events->getListeners($event);
 
         $foundListener = false;
-        foreach ($listeners as $listener) {
-            $callback = $listener->getCallback();
-            $foundListener = $callback === [$listenerService, $method];
+        foreach ($this->getListenersForEvent($event, $events) as $listener) {
+            $foundListener = $listener === [$listenerService, $method];
             if ($foundListener) {
                 break;
             }
@@ -175,7 +176,7 @@ class ApplicationTest extends TestCase
 
     public function testBootstrapAlwaysRegistersDefaultListeners()
     {
-        $refl = new \ReflectionProperty($this->application, 'defaultListeners');
+        $refl = new ReflectionProperty($this->application, 'defaultListeners');
         $refl->setAccessible(true);
         $defaultListenersNames = $refl->getValue($this->application);
         $defaultListeners = [];
@@ -187,11 +188,12 @@ class ApplicationTest extends TestCase
         $eventManager = $this->application->getEventManager();
 
         $registeredListeners = [];
-        foreach ($eventManager->getEvents() as $event) {
-            $listeners = $eventManager->getListeners($event);
-            foreach ($listeners as $listener) {
-                $callback = $listener->getCallBack();
-                $registeredListeners[] = $callback[0];
+        foreach ($this->getEventsFromEventManager($eventManager) as $event) {
+            foreach ($this->getListenersForEvent($event, $eventManager) as $listener) {
+                if (is_array($listener)) {
+                    $listener = array_shift($listener);
+                }
+                $registeredListeners[] = $listener;
             }
         }
 
@@ -302,7 +304,7 @@ class ApplicationTest extends TestCase
 
         $this->application->run();
         $this->assertArrayHasKey('route-match', $log);
-        $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $log['route-match']);
+        $this->assertInstanceOf(Router\RouteMatch::class, $log['route-match']);
     }
 
     public function testAllowsReturningEarlyFromRouting()
@@ -647,7 +649,7 @@ class ApplicationTest extends TestCase
     {
         $this->application->bootstrap();
 
-        $response     = $this->getMock('Zend\Stdlib\ResponseInterface');
+        $response     = $this->getMock(ResponseInterface::class);
         $finishMock   = $this->getMock('stdClass', ['__invoke']);
         $routeMock    = $this->getMock('stdClass', ['__invoke']);
         $dispatchMock = $this->getMock('stdClass', ['__invoke']);
@@ -673,7 +675,7 @@ class ApplicationTest extends TestCase
     {
         $this->application->bootstrap();
 
-        $response     = $this->getMock('Zend\Stdlib\ResponseInterface');
+        $response     = $this->getMock(ResponseInterface::class);
         $errorMock    = $this->getMock('stdClass', ['__invoke']);
         $finishMock   = $this->getMock('stdClass', ['__invoke']);
         $routeMock    = $this->getMock('stdClass', ['__invoke']);
@@ -686,8 +688,9 @@ class ApplicationTest extends TestCase
         }));
         $routeMock->expects($this->once())->method('__invoke')->will($this->returnCallback(function (MvcEvent $event) {
             $event->stopPropagation(true);
+            $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
             $event->setError(Application::ERROR_ROUTER_NO_MATCH);
-            return $event->getApplication()->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $event)->last();
+            return $event->getApplication()->getEventManager()->triggerEvent($event)->last();
         }));
         $dispatchMock->expects($this->once())->method('__invoke')->will($this->returnValue($response));
         $finishMock->expects($this->once())->method('__invoke')->will($this->returnCallback(function (MvcEvent $event) {
@@ -740,7 +743,9 @@ class ApplicationTest extends TestCase
             $marker->{$e->getName()} = $e->propagationIsStopped();
             $e->stopPropagation(true);
         };
-        $this->application->getEventManager()->attach($events, $listener);
+        foreach ($events as $event) {
+            $this->application->getEventManager()->attach($event, $listener);
+        }
 
         $this->application->run();
 

--- a/test/Controller/ActionControllerTest.php
+++ b/test/Controller/ActionControllerTest.php
@@ -11,8 +11,8 @@ namespace ZendTest\Mvc\Controller;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Console\Response as ConsoleResponse;
+use Zend\EventManager\EventManager;
 use Zend\EventManager\SharedEventManager;
-use Zend\EventManager\StaticEventManager;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Mvc\Controller\PluginManager;
@@ -28,7 +28,6 @@ class ActionControllerTest extends TestCase
 
     public function setUp()
     {
-        StaticEventManager::resetInstance();
         $this->controller = new TestAsset\SampleController();
         $this->request    = new Request();
         $this->response   = null;
@@ -36,6 +35,10 @@ class ActionControllerTest extends TestCase
         $this->event      = new MvcEvent();
         $this->event->setRouteMatch($this->routeMatch);
         $this->controller->setEvent($this->event);
+
+        $this->sharedEvents = new SharedEventManager();
+        $this->events       = new EventManager($this->sharedEvents);
+        $this->controller->setEventManager($this->events);
     }
 
     public function testDispatchInvokesNotFoundActionWhenNoActionPresentInRouteMatch()
@@ -105,11 +108,10 @@ class ActionControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = new SharedEventManager();
-        $events->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, function ($e) use ($response) {
+        $sharedEvents = $this->controller->getEventManager()->getSharedManager();
+        $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, function ($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->getEventManager()->setSharedManager($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -118,11 +120,10 @@ class ActionControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = new SharedEventManager();
-        $events->attach('Zend\Mvc\Controller\AbstractActionController', MvcEvent::EVENT_DISPATCH, function ($e) use ($response) {
+        $sharedEvents = $this->controller->getEventManager()->getSharedManager();
+        $sharedEvents->attach('Zend\Mvc\Controller\AbstractActionController', MvcEvent::EVENT_DISPATCH, function ($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->getEventManager()->setSharedManager($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -131,11 +132,10 @@ class ActionControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = new SharedEventManager();
-        $events->attach(get_class($this->controller), MvcEvent::EVENT_DISPATCH, function ($e) use ($response) {
+        $sharedEvents = $this->controller->getEventManager()->getSharedManager();
+        $sharedEvents->attach(get_class($this->controller), MvcEvent::EVENT_DISPATCH, function ($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->getEventManager()->setSharedManager($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }
@@ -144,11 +144,10 @@ class ActionControllerTest extends TestCase
     {
         $response = new Response();
         $response->setContent('short circuited!');
-        $events = new SharedEventManager();
-        $events->attach('ZendTest\\Mvc\\Controller\\TestAsset\\SampleInterface', MvcEvent::EVENT_DISPATCH, function ($e) use ($response) {
+        $sharedEvents = $this->controller->getEventManager()->getSharedManager();
+        $sharedEvents->attach('ZendTest\\Mvc\\Controller\\TestAsset\\SampleInterface', MvcEvent::EVENT_DISPATCH, function ($e) use ($response) {
             return $response;
         }, 10);
-        $this->controller->getEventManager()->setSharedManager($events);
         $result = $this->controller->dispatch($this->request, $this->response);
         $this->assertSame($response, $result);
     }

--- a/test/Controller/ControllerManagerTest.php
+++ b/test/Controller/ControllerManagerTest.php
@@ -21,10 +21,10 @@ class ControllerManagerTest extends TestCase
 {
     public function setUp()
     {
-        $this->events       = new EventManager();
-        $this->consoleAdapter = new ConsoleAdapter();
         $this->sharedEvents = new SharedEventManager;
-        $this->events->setSharedManager($this->sharedEvents);
+        $this->events       = new EventManager($this->sharedEvents);
+
+        $this->consoleAdapter = new ConsoleAdapter();
 
         $this->plugins  = new ControllerPluginManager();
         $this->services = new ServiceManager();
@@ -63,7 +63,7 @@ class ControllerManagerTest extends TestCase
 
     public function testInjectControllerDependenciesWillNotOverwriteExistingEventManager()
     {
-        $events     = new EventManager();
+        $events     = new EventManager($this->sharedEvents);
         $controller = new TestAsset\SampleController();
         $controller->setEventManager($events);
         $this->controllers->injectControllerDependencies($controller, $this->controllers);

--- a/test/Controller/IntegrationTest.php
+++ b/test/Controller/IntegrationTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Mvc\Controller;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\EventManager;
 use Zend\EventManager\SharedEventManager;
 use Zend\Mvc\Controller\ControllerManager;
 use Zend\Mvc\Controller\PluginManager;
@@ -20,11 +21,14 @@ class IntegrationTest extends TestCase
     public function setUp()
     {
         $this->plugins      = new PluginManager();
-        $this->sharedEvents = new SharedEventManager();
+        $this->sharedEvents = $sharedEvents = new SharedEventManager();
         $this->services     = new ServiceManager();
         $this->services->setService('ControllerPluginManager', $this->plugins);
         $this->services->setService('SharedEventManager', $this->sharedEvents);
         $this->services->setService('Zend\ServiceManager\ServiceLocatorInterface', $this->services);
+        $this->services->setFactory('EventManager', function ($services) use ($sharedEvents) {
+            return new EventManager($sharedEvents);
+        });
 
         $this->controllers = new ControllerManager();
         $this->controllers->setServiceLocator($this->services);

--- a/test/EventManagerIntrospectionTrait.php
+++ b/test/EventManagerIntrospectionTrait.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc;
+
+use ReflectionProperty;
+use Zend\EventManager\EventManager;
+
+/**
+ * Offer methods for introspecting event manager events and listeners.
+ */
+trait EventManagerIntrospectionTrait
+{
+    public function getEventsFromEventManager(EventManager $events)
+    {
+        $r = new ReflectionProperty($events, 'events');
+        $r->setAccessible(true);
+        $listeners = $r->getValue($events);
+        return array_keys($listeners);
+    }
+
+    public function getListenersForEvent($event, EventManager $events, $withPriority = false)
+    {
+        $r = new ReflectionProperty($events, 'events');
+        $r->setAccessible(true);
+        $listeners = $r->getValue($events);
+
+        if (! isset($listeners[$event])) {
+            return $this->traverseListeners([]);
+        }
+
+        return $this->traverseListeners($listeners[$event], $withPriority);
+    }
+
+    public function traverseListeners(array $queue, $withPriority = false)
+    {
+        krsort($queue, SORT_NUMERIC);
+
+        foreach ($queue as $priority => $listeners) {
+            $priority = (int) $priority;
+            foreach ($listeners as $listener) {
+                if ($withPriority) {
+                    yield $priority => $listener;
+                } else {
+                    yield $listener;
+                }
+            }
+        }
+    }
+}

--- a/test/ModuleRouteListenerTest.php
+++ b/test/ModuleRouteListenerTest.php
@@ -27,8 +27,8 @@ class ModuleRouteListenerTest extends TestCase
         $this->routeListener       = new RouteListener();
         $this->moduleRouteListener = new ModuleRouteListener();
 
-        $this->events->attach($this->routeListener);
-        $this->events->attach($this->moduleRouteListener, -1);
+        $this->routeListener->attach($this->events);
+        $this->moduleRouteListener->attach($this->events, -1);
     }
 
     public function testRouteReturningModuleNamespaceInRouteMatchTriggersControllerRename()
@@ -45,9 +45,10 @@ class ModuleRouteListenerTest extends TestCase
         ]);
         $this->request->setUri('/foo');
         $event = new MvcEvent();
+        $event->setName('route');
         $event->setRouter($this->router);
         $event->setRequest($this->request);
-        $this->events->trigger('route', $event);
+        $this->events->triggerEvent($event);
 
         $matches = $event->getRouteMatch();
         $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $matches);
@@ -68,9 +69,10 @@ class ModuleRouteListenerTest extends TestCase
         ]);
         $this->request->setUri('/foo');
         $event = new MvcEvent();
+        $event->setName('route');
         $event->setRouter($this->router);
         $event->setRequest($this->request);
-        $this->events->trigger('route', $event);
+        $this->events->triggerEvent($event);
 
         $matches = $event->getRouteMatch();
         $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $matches);
@@ -80,7 +82,7 @@ class ModuleRouteListenerTest extends TestCase
     public function testMultipleRegistrationShouldNotResultInMultiplePrefixingOfControllerName()
     {
         $moduleListener = new ModuleRouteListener();
-        $this->events->attach($moduleListener);
+        $moduleListener->attach($this->events);
 
         $this->router->addRoute('foo', [
             'type' => 'Literal',
@@ -94,9 +96,10 @@ class ModuleRouteListenerTest extends TestCase
         ]);
         $this->request->setUri('/foo');
         $event = new MvcEvent();
+        $event->setName('route');
         $event->setRouter($this->router);
         $event->setRequest($this->request);
-        $this->events->trigger('route', $event);
+        $this->events->triggerEvent($event);
 
         $matches = $event->getRouteMatch();
         $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $matches);
@@ -107,7 +110,7 @@ class ModuleRouteListenerTest extends TestCase
     public function testRouteMatchIsTransformedToProperControllerClassName()
     {
         $moduleListener = new ModuleRouteListener();
-        $this->events->attach($moduleListener);
+        $moduleListener->attach($this->events);
 
         $this->router->addRoute('foo', [
             'type' => 'Literal',
@@ -122,9 +125,10 @@ class ModuleRouteListenerTest extends TestCase
 
         $this->request->setUri('/foo');
         $event = new MvcEvent();
+        $event->setName('route');
         $event->setRouter($this->router);
         $event->setRequest($this->request);
-        $this->events->trigger('route', $event);
+        $this->events->triggerEvent($event);
 
         $matches = $event->getRouteMatch();
         $this->assertInstanceOf('Zend\Mvc\Router\RouteMatch', $matches);

--- a/test/Service/ServiceManagerConfigTest.php
+++ b/test/Service/ServiceManagerConfigTest.php
@@ -45,7 +45,7 @@ class ServiceManagerConfigTest extends TestCase
      */
     public function testEventManagerAwareInterfaceIsNotInjectedIfPresentButSharedManagerIs()
     {
-        $events = new EventManager();
+        $events = new EventManager($this->services->get('SharedEventManager'));
         TestAsset\EventManagerAwareObject::$defaultEvents = $events;
 
         $this->services->setInvokableClass('EventManagerAwareObject', __NAMESPACE__ . '\TestAsset\EventManagerAwareObject');

--- a/test/TestAsset/MockSendResponseListener.php
+++ b/test/TestAsset/MockSendResponseListener.php
@@ -15,7 +15,7 @@ use Zend\Mvc\MvcEvent;
 
 class MockSendResponseListener extends AbstractListenerAggregate
 {
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_FINISH, array($this, 'sendResponse'), -10000);
     }

--- a/test/TestAsset/MockViewManager.php
+++ b/test/TestAsset/MockViewManager.php
@@ -15,7 +15,7 @@ use Zend\Mvc\MvcEvent;
 
 class MockViewManager extends AbstractListenerAggregate
 {
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_BOOTSTRAP, array($this, 'onBootstrap'), 10000);
     }

--- a/test/TestAsset/StubBootstrapListener.php
+++ b/test/TestAsset/StubBootstrapListener.php
@@ -20,7 +20,7 @@ class StubBootstrapListener implements ListenerAggregateInterface
     /**
      * @see \Zend\EventManager\ListenerAggregateInterface::attach()
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_BOOTSTRAP, array($this, 'onBootstrap'));
     }

--- a/test/View/Console/DefaultRenderingStrategyTest.php
+++ b/test/View/Console/DefaultRenderingStrategyTest.php
@@ -24,7 +24,7 @@ class DefaultRenderingStrategyTest extends TestCase
 {
     use EventManagerIntrospectionTrait;
 
-    /* @var DefaultRenderingStrategy */
+    /** @var DefaultRenderingStrategy */
     protected $strategy;
 
     public function setUp()
@@ -36,22 +36,13 @@ class DefaultRenderingStrategyTest extends TestCase
     {
         $events = new EventManager();
         $this->strategy->attach($events);
-        $listeners = $this->getListenersForEvent(MvcEvent::EVENT_RENDER, $events, true);
-
-        $expectedListener = [$this->strategy, 'render'];
-        $expectedPriority = -10000;
-        $found            = false;
-
-        /* @var \Zend\Stdlib\CallbackHandler $listener */
-        foreach ($listeners as $priority => $listener) {
-            if ($listener === $expectedListener
-                && $priority === $expectedPriority
-            ) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'Renderer not found');
+        $this->assertListenerAtPriority(
+            [$this->strategy, 'render'],
+            -10000,
+            MvcEvent::EVENT_RENDER,
+            $events,
+            'Renderer listener not found'
+        );
     }
 
     public function testCanDetachListenersFromEventManager()
@@ -59,11 +50,11 @@ class DefaultRenderingStrategyTest extends TestCase
         $events = new EventManager();
         $this->strategy->attach($events);
 
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_RENDER, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_RENDER, $events);
         $this->assertCount(1, $listeners);
 
         $this->strategy->detach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_RENDER, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_RENDER, $events);
         $this->assertCount(0, $listeners);
     }
 

--- a/test/View/Console/ExceptionStrategyTest.php
+++ b/test/View/Console/ExceptionStrategyTest.php
@@ -33,33 +33,21 @@ class ExceptionStrategyTest extends TestCase
         $events = new EventManager();
         $this->strategy->attach($events);
 
-        $listeners        = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events, true);
-        $expectedListener = [$this->strategy, 'prepareExceptionViewModel'];
-        $expectedPriority = 1;
-        $found            = false;
-        foreach ($listeners as $priority => $listener) {
-            if ($listener === $expectedListener
-                && $priority === $expectedPriority
-            ) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'MvcEvent::EVENT_DISPATCH_ERROR not found');
+        $this->assertListenerAtPriority(
+            [$this->strategy, 'prepareExceptionViewModel'],
+            1,
+            MvcEvent::EVENT_DISPATCH_ERROR,
+            $events,
+            'MvcEvent::EVENT_DISPATCH_ERROR listener not found'
+        );
 
-        $listeners        = $this->getListenersForEvent(MvcEvent::EVENT_RENDER_ERROR, $events, true);
-        $expectedListener = [$this->strategy, 'prepareExceptionViewModel'];
-        $expectedPriority = 1;
-        $found            = false;
-        foreach ($listeners as $priority => $listener) {
-            if ($listener === $expectedListener
-                && $priority === $expectedPriority
-            ) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'MvcEvent::EVENT_RENDER_ERROR not found');
+        $this->assertListenerAtPriority(
+            [$this->strategy, 'prepareExceptionViewModel'],
+            1,
+            MvcEvent::EVENT_RENDER_ERROR,
+            $events,
+            'MvcEvent::EVENT_RENDER_ERROR listener not found'
+        );
     }
 
     public function testDefaultDisplayExceptions()

--- a/test/View/Console/ViewManagerTest.php
+++ b/test/View/Console/ViewManagerTest.php
@@ -107,17 +107,18 @@ class ViewManagerTest extends TestCase
      */
     public function testConsoleKeyWillOverrideDisplayExceptionAndDisplayNotFoundReason($config)
     {
-        $eventManager = new EventManager();
-        $eventManager->setSharedManager(new SharedEventManager());
+        $eventManager = new EventManager(new SharedEventManager());
+        $request      = new ConsoleRequest();
+        $response     = new ConsoleResponse();
 
         $this->services->setService('Config', $config);
-        $this->services->setService('Request', new ConsoleRequest());
+        $this->services->setService('Request', $request);
         $this->services->setService('EventManager', $eventManager);
-        $this->services->setService('Response', new ConsoleResponse());
+        $this->services->setService('Response', $response);
 
         $manager = $this->factory->createService($this->services);
 
-        $application = new Application($config, $this->services);
+        $application = new Application($config, $this->services, $eventManager, $request, $response);
 
         $event = new MvcEvent();
         $event->setApplication($application);
@@ -132,17 +133,18 @@ class ViewManagerTest extends TestCase
      */
     public function testConsoleDisplayExceptionIsTrue()
     {
-        $eventManager = new EventManager();
-        $eventManager->setSharedManager(new SharedEventManager());
+        $eventManager = new EventManager(new SharedEventManager());
+        $request      = new ConsoleRequest();
+        $response     = new ConsoleResponse();
 
         $this->services->setService('Config', []);
-        $this->services->setService('Request', new ConsoleRequest());
+        $this->services->setService('Request', $request);
         $this->services->setService('EventManager', $eventManager);
-        $this->services->setService('Response', new ConsoleResponse());
+        $this->services->setService('Response', $response);
 
         $manager = $this->factory->createService($this->services);
 
-        $application = new Application([], $this->services);
+        $application = new Application([], $this->services, $eventManager, $request, $response);
 
         $event = new MvcEvent();
         $event->setApplication($application);

--- a/test/View/CreateViewModelListenerTest.php
+++ b/test/View/CreateViewModelListenerTest.php
@@ -14,9 +14,12 @@ use stdClass;
 use Zend\EventManager\EventManager;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\View\Http\CreateViewModelListener;
+use ZendTest\Mvc\EventManagerIntrospectionTrait;
 
 class CreateViewModelListenerTest extends TestCase
 {
+    use EventManagerIntrospectionTrait;
+
     public function setUp()
     {
         $this->listener   = new CreateViewModelListener();
@@ -69,39 +72,42 @@ class CreateViewModelListenerTest extends TestCase
     public function testAttachesListenersAtExpectedPriority()
     {
         $events = new EventManager();
-        $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+        $this->listener->attach($events);
+        $listeners = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events, true);
 
-        $expectedArrayCallback = [$this->listener, 'createViewModelFromArray'];
-        $expectedNullCallback  = [$this->listener, 'createViewModelFromNull'];
+        $expectedArrayListener = [$this->listener, 'createViewModelFromArray'];
+        $expectedNullListener  = [$this->listener, 'createViewModelFromNull'];
         $expectedPriority      = -80;
         $foundArray            = false;
         $foundNull             = false;
-        foreach ($listeners as $listener) {
-            $callback = $listener->getCallback();
-            if ($callback === $expectedArrayCallback) {
-                if ($listener->getMetadatum('priority') == $expectedPriority) {
-                    $foundArray = true;
-                }
+        foreach ($listeners as $priority => $listener) {
+            if ($listener === $expectedArrayListener
+                && $priority === $expectedPriority
+            ) {
+                $foundArray = true;
+                continue;
             }
-            if ($callback === $expectedNullCallback) {
-                if ($listener->getMetadatum('priority') == $expectedPriority) {
-                    $foundNull = true;
-                }
+
+            if ($listener === $expectedNullListener
+                && $priority === $expectedPriority
+            ) {
+                $foundNull = true;
+                continue;
             }
         }
         $this->assertTrue($foundArray, 'Listener FromArray not found');
-        $this->assertTrue($foundNull,  'Listener FromNull not found');
+        $this->assertTrue($foundNull, 'Listener FromNull not found');
     }
 
     public function testDetachesListeners()
     {
         $events = new EventManager();
-        $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+        $this->listener->attach($events);
+        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
         $this->assertEquals(2, count($listeners));
-        $events->detachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+
+        $this->listener->detach($events);
+        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
         $this->assertEquals(0, count($listeners));
     }
 

--- a/test/View/CreateViewModelListenerTest.php
+++ b/test/View/CreateViewModelListenerTest.php
@@ -73,41 +73,31 @@ class CreateViewModelListenerTest extends TestCase
     {
         $events = new EventManager();
         $this->listener->attach($events);
-        $listeners = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events, true);
-
-        $expectedArrayListener = [$this->listener, 'createViewModelFromArray'];
-        $expectedNullListener  = [$this->listener, 'createViewModelFromNull'];
-        $expectedPriority      = -80;
-        $foundArray            = false;
-        $foundNull             = false;
-        foreach ($listeners as $priority => $listener) {
-            if ($listener === $expectedArrayListener
-                && $priority === $expectedPriority
-            ) {
-                $foundArray = true;
-                continue;
-            }
-
-            if ($listener === $expectedNullListener
-                && $priority === $expectedPriority
-            ) {
-                $foundNull = true;
-                continue;
-            }
-        }
-        $this->assertTrue($foundArray, 'Listener FromArray not found');
-        $this->assertTrue($foundNull, 'Listener FromNull not found');
+        $this->assertListenerAtPriority(
+            [$this->listener, 'createViewModelFromArray'],
+            -80,
+            MvcEvent::EVENT_DISPATCH,
+            $events,
+            'Did not find createViewModelFromArray listener in event list at expected priority'
+        );
+        $this->assertListenerAtPriority(
+            [$this->listener, 'createViewModelFromNull'],
+            -80,
+            MvcEvent::EVENT_DISPATCH,
+            $events,
+            'Did not find createViewModelFromNull listener in event list at expected priority'
+        );
     }
 
     public function testDetachesListeners()
     {
         $events = new EventManager();
         $this->listener->attach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
         $this->assertEquals(2, count($listeners));
 
         $this->listener->detach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
         $this->assertEquals(0, count($listeners));
     }
 

--- a/test/View/DefaultRendereringStrategyTest.php
+++ b/test/View/DefaultRendereringStrategyTest.php
@@ -57,20 +57,13 @@ class DefaultRendereringStrategyTest extends TestCase
         $events = [MvcEvent::EVENT_RENDER, MvcEvent::EVENT_RENDER_ERROR];
 
         foreach ($events as $event) {
-            $listeners = $this->getListenersForEvent($event, $evm, true);
-
-            $expectedListener = [$this->strategy, 'render'];
-            $expectedPriority = -10000;
-            $found            = false;
-            foreach ($listeners as $priority => $listener) {
-                if ($listener === $expectedListener
-                    && $priority === $expectedPriority
-                ) {
-                    $found = true;
-                    break;
-                }
-            }
-            $this->assertTrue($found, 'Renderer not found');
+            $this->assertListenerAtPriority(
+                [$this->strategy, 'render'],
+                -10000,
+                $event,
+                $evm,
+                'Renderer not found'
+            );
         }
     }
 
@@ -78,11 +71,11 @@ class DefaultRendereringStrategyTest extends TestCase
     {
         $events = new EventManager();
         $this->strategy->attach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_RENDER, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_RENDER, $events);
         $this->assertCount(1, $listeners);
 
         $this->strategy->detach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_RENDER, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_RENDER, $events);
         $this->assertCount(0, $listeners);
     }
 

--- a/test/View/ExceptionStrategyTest.php
+++ b/test/View/ExceptionStrategyTest.php
@@ -138,30 +138,23 @@ class ExceptionStrategyTest extends TestCase
     {
         $events = new EventManager();
         $this->strategy->attach($events);
-        $listeners = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events, true);
 
-        $expectedListener = [$this->strategy, 'prepareExceptionViewModel'];
-        $expectedPriority = 1;
-        $found            = false;
-        foreach ($listeners as $priority => $listener) {
-            if ($listener === $expectedListener
-                && $priority === $expectedPriority
-            ) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'Listener not found');
+        $this->assertListenerAtPriority(
+            [$this->strategy, 'prepareExceptionViewModel'],
+            1,
+            MvcEvent::EVENT_DISPATCH_ERROR,
+            $events
+        );
     }
 
     public function testDetachesListeners()
     {
         $events = new EventManager();
         $this->strategy->attach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
         $this->assertEquals(1, count($listeners));
         $this->strategy->detach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
         $this->assertEquals(0, count($listeners));
     }
 

--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -307,31 +307,23 @@ class InjectTemplateListenerTest extends TestCase
     {
         $events = new EventManager();
         $this->listener->attach($events);
-        $listeners = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events, true);
-
-        $expectedListener = [$this->listener, 'injectTemplate'];
-        $expectedPriority = -90;
-        $found            = false;
-        foreach ($listeners as $priority => $listener) {
-            if ($listener === $expectedListener
-                && $priority === $expectedPriority
-            ) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'Listener not found');
+        $this->assertListenerAtPriority(
+            [$this->listener, 'injectTemplate'],
+            -90,
+            MvcEvent::EVENT_DISPATCH,
+            $events
+        );
     }
 
     public function testDetachesListeners()
     {
         $events = new EventManager();
         $this->listener->attach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events, true));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
         $this->assertEquals(1, count($listeners));
 
         $this->listener->detach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events, true));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
         $this->assertEquals(0, count($listeners));
     }
 

--- a/test/View/InjectViewModelListenerTest.php
+++ b/test/View/InjectViewModelListenerTest.php
@@ -67,32 +67,19 @@ class InjectViewModelListenerTest extends TestCase
     {
         $events = new EventManager();
         $this->listener->attach($events);
-        $listeners = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events, true);
+        $this->assertListenerAtPriority(
+            [$this->listener, 'injectViewModel'],
+            -100,
+            MvcEvent::EVENT_DISPATCH,
+            $events
+        );
 
-        $expectedListener = [$this->listener, 'injectViewModel'];
-        $expectedPriority = -100;
-        $found            = false;
-        foreach ($listeners as $priority => $listener) {
-            if ($listener === $expectedListener
-                && $priority === $expectedPriority
-            ) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'Listener not found');
-
-        $listeners = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events, true);
-        $found     = false;
-        foreach ($listeners as $listener) {
-            if ($listener === $expectedListener
-                && $priority === $expectedPriority
-            ) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'Listener not found');
+        $this->assertListenerAtPriority(
+            [$this->listener, 'injectViewModel'],
+            -100,
+            MvcEvent::EVENT_DISPATCH_ERROR,
+            $events
+        );
     }
 
     public function testDetachesListeners()
@@ -100,15 +87,15 @@ class InjectViewModelListenerTest extends TestCase
         $events = new EventManager();
         $this->listener->attach($events);
 
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
         $this->assertCount(1, $listeners);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
         $this->assertCount(1, $listeners);
 
         $this->listener->detach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
         $this->assertCount(0, $listeners);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
         $this->assertCount(0, $listeners);
     }
 }

--- a/test/View/InjectViewModelListenerTest.php
+++ b/test/View/InjectViewModelListenerTest.php
@@ -15,9 +15,12 @@ use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\View\Http\InjectViewModelListener;
 use Zend\View\Model\ViewModel;
+use ZendTest\Mvc\EventManagerIntrospectionTrait;
 
 class InjectViewModelListenerTest extends TestCase
 {
+    use EventManagerIntrospectionTrait;
+
     public function setUp()
     {
         $this->listener   = new InjectViewModelListener();
@@ -63,32 +66,30 @@ class InjectViewModelListenerTest extends TestCase
     public function testAttachesListenersAtExpectedPriorities()
     {
         $events = new EventManager();
-        $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+        $this->listener->attach($events);
+        $listeners = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events, true);
 
-        $expectedCallback = [$this->listener, 'injectViewModel'];
+        $expectedListener = [$this->listener, 'injectViewModel'];
         $expectedPriority = -100;
         $found            = false;
-        foreach ($listeners as $listener) {
-            $callback = $listener->getCallback();
-            if ($callback === $expectedCallback) {
-                if ($listener->getMetadatum('priority') == $expectedPriority) {
-                    $found = true;
-                    break;
-                }
+        foreach ($listeners as $priority => $listener) {
+            if ($listener === $expectedListener
+                && $priority === $expectedPriority
+            ) {
+                $found = true;
+                break;
             }
         }
         $this->assertTrue($found, 'Listener not found');
 
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
+        $listeners = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events, true);
         $found     = false;
         foreach ($listeners as $listener) {
-            $callback = $listener->getCallback();
-            if ($callback === $expectedCallback) {
-                if ($listener->getMetadatum('priority') == $expectedPriority) {
-                    $found = true;
-                    break;
-                }
+            if ($listener === $expectedListener
+                && $priority === $expectedPriority
+            ) {
+                $found = true;
+                break;
             }
         }
         $this->assertTrue($found, 'Listener not found');
@@ -97,15 +98,17 @@ class InjectViewModelListenerTest extends TestCase
     public function testDetachesListeners()
     {
         $events = new EventManager();
-        $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
-        $this->assertEquals(1, count($listeners));
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
-        $this->assertEquals(1, count($listeners));
-        $events->detachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
-        $this->assertEquals(0, count($listeners));
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
-        $this->assertEquals(0, count($listeners));
+        $this->listener->attach($events);
+
+        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
+        $this->assertCount(1, $listeners);
+        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events));
+        $this->assertCount(1, $listeners);
+
+        $this->listener->detach($events);
+        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
+        $this->assertCount(0, $listeners);
+        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events));
+        $this->assertCount(0, $listeners);
     }
 }

--- a/test/View/RouteNotFoundStrategyTest.php
+++ b/test/View/RouteNotFoundStrategyTest.php
@@ -294,49 +294,36 @@ class RouteNotFoundStrategyTest extends TestCase
         $this->strategy->attach($events);
 
         foreach ([MvcEvent::EVENT_DISPATCH => -90, MvcEvent::EVENT_DISPATCH_ERROR => 1] as $event => $expectedPriority) {
-            $listeners        = $this->getListenersForEvent($event, $events, true);
-            $expectedListener = [$this->strategy, 'prepareNotFoundViewModel'];
-            $found            = false;
-            foreach ($listeners as $priority => $listener) {
-                if ($listener === $expectedListener
-                    && $priority === $expectedPriority
-                ) {
-                    $found = true;
-                    break;
-                }
-            }
-            $this->assertTrue($found, 'Listener not found');
+            $this->assertListenerAtPriority(
+                [$this->strategy, 'prepareNotFoundViewModel'],
+                $expectedPriority,
+                $event,
+                $events
+            );
         }
 
-        $listeners        = $this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events, true);
-        $expectedListener = [$this->strategy, 'detectNotFoundError'];
-        $expectedPriority = 1;
-        $found            = false;
-        foreach ($listeners as $priority => $listener) {
-            if ($listener === $expectedListener
-                && $priority === $expectedPriority
-            ) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'Listener not found');
+        $this->assertListenerAtPriority(
+            [$this->strategy, 'detectNotFoundError'],
+            1,
+            $event,
+            $events
+        );
     }
 
     public function testDetachesListeners()
     {
         $events = new EventManager();
         $this->strategy->attach($events);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
         $this->assertCount(1, $listeners);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
         $this->assertCount(2, $listeners);
 
         $this->strategy->detach($events);
 
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH, $events);
         $this->assertCount(0, $listeners);
-        $listeners = iterator_to_array($this->getListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events));
+        $listeners = $this->getArrayOfListenersForEvent(MvcEvent::EVENT_DISPATCH_ERROR, $events);
         $this->assertCount(0, $listeners);
     }
 }


### PR DESCRIPTION
Updates all code to work with the upcoming v3 of EventManager. In particular:
- Updated the EventManager factory to inject the SharedEventManager at instantiation, if that service is present.
- Updated the EventManager initializer to inject not only if no EM instance is present, but also if the current EM instance has no shared manager present.  The latter is a good indication that the EM instance was lazy-loaded by the getter.
- Updated the Application constructor to pass arguments. This was necessary due to a strange circular dependency with the changes to the initializer. It's also better DI.
- Fixed all `attachAggregate()` calls to use `$aggregate->attach()`, and ensured there were no calls to `$events->attach()` that were attaching aggregates.
- Reviewed all `trigger()` calls for appropriate signatures, updating those that needed it. In many cases, an additional call to `$event->setName()` was also required.

This can likely be merged to develop sooner rather than later, as it represents a work-in-progress towards the updated MVC.
