### PR TITLE
Add a middleware dispatch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-hydrator": "~1.0",
         "zendframework/zend-form": "~2.6",
-        "zendframework/zend-stdlib": "~2.7"
+        "zendframework/zend-stdlib": "~2.7",
+        "zendframework/zend-psr7bridge": "^0.2"
     },
     "require-dev": {
         "zendframework/zend-authentication": "~2.5",

--- a/src/Application.php
+++ b/src/Application.php
@@ -27,6 +27,7 @@ use Zend\Stdlib\ResponseInterface;
  * - RouteListener
  * - Router
  * - DispatchListener
+ * - MiddlewareListener
  * - ViewManager
  *
  * The most common workflow is:
@@ -53,7 +54,7 @@ class Application implements
     const ERROR_EXCEPTION                  = 'error-exception';
     const ERROR_ROUTER_NO_MATCH            = 'error-router-no-match';
     const ERROR_MIDDLEWARE_CANNOT_DISPATCH = 'error-middleware-cannot-dispatch';
-    
+
     /**
      * @var array
      */
@@ -66,6 +67,7 @@ class Application implements
      */
     protected $defaultListeners = [
         'RouteListener',
+        'MiddlewareListener',
         'DispatchListener',
         'HttpMethodListener',
         'ViewManager',

--- a/src/Application.php
+++ b/src/Application.php
@@ -52,7 +52,8 @@ class Application implements
     const ERROR_CONTROLLER_INVALID         = 'error-controller-invalid';
     const ERROR_EXCEPTION                  = 'error-exception';
     const ERROR_ROUTER_NO_MATCH            = 'error-router-no-match';
-
+    const ERROR_MIDDLEWARE_CANNOT_DISPATCH = 'error-middleware-cannot-dispatch';
+    
     /**
      * @var array
      */

--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc;
+
+use ArrayObject;
+use Zend\EventManager\AbstractListenerAggregate;
+use Zend\EventManager\EventManagerInterface;
+use Zend\Mvc\Exception\InvalidControllerException;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Psr7Bridge\Psr7ServerRequest as Psr7Request;
+use Zend\Psr7Bridge\Psr7Response;
+
+class MiddlewareListener extends AbstractListenerAggregate
+{
+    /**
+     * Attach listeners to an event manager
+     *
+     * @param  EventManagerInterface $events
+     * @return void
+     */
+    public function attach(EventManagerInterface $events)
+    {
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, [$this, 'onDispatch'], 1000);
+    }
+
+    /**
+     * Listen to the "dispatch" event
+     *
+     * @param  MvcEvent $e
+     * @return mixed
+     */
+    public function onDispatch(MvcEvent $e)
+    {
+        $routeMatch = $e->getRouteMatch();
+        $middleware = $routeMatch->getParam('middleware', false);
+        if (false === $middleware) {
+            return;
+        }
+
+        $request        = $e->getRequest();
+        $application    = $e->getApplication();
+        $response       = $application->getResponse();
+        $serviceManager = $application->getServiceManager();
+        $middlewareName = is_string($middleware) ? $middleware : get_class($middleware);
+
+        if (is_string($middleware) && $serviceManager->has($middleware)) {
+            $middleware = $serviceManager->get($middleware);
+        }
+        if (!is_callable($middleware)) {
+            $return = $this->marshalMiddlewareNotCallable($application::ERROR_MIDDLEWARE_CANNOT_DISPATCH, $middlewareName, $e, $application);
+            $e->setResult($return);
+            return $return;
+        }
+        try {
+            $return = $middleware(Psr7Request::fromZend($request), Psr7Response::fromZend($response));
+        } catch (\Exception $ex) {
+          $e->setError($application::ERROR_EXCEPTION)
+            ->setController($middlewareName)
+            ->setControllerClass(get_class($middleware))
+            ->setParam('exception', $ex);
+          $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $e);
+          $return = $results->last();
+          if (! $return) {
+              $return = $e->getResult();
+          }
+        }
+
+        if (! $return instanceof \Psr\Http\Message\ResponseInterface) {
+            $e->setResult($return);
+            return $return;
+        }
+        $response = Psr7Response::toZend($return);
+        $e->setResult($response);
+        return $response;
+    }
+
+    /**
+     * Marshal a middleware not callable exception event
+     *
+     * @param  string $type
+     * @param  string $middlewareName
+     * @param  MvcEvent $event
+     * @param  Application $application
+     * @param  \Exception $exception
+     * @return mixed
+     */
+    protected function marshalMiddlewareNotCallable(
+        $type,
+        $middlewareName,
+        MvcEvent $event,
+        Application $application,
+        \Exception $exception = null
+    ) {
+        $event->setError($type)
+              ->setController($middlewareName)
+              ->setControllerClass('Middleware not callable: ' . $middlewareName);
+        if ($exception !== null) {
+            $event->setParam('exception', $exception);
+        }
+
+        $events  = $application->getEventManager();
+        $results = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $event);
+        $return  = $results->last();
+        if (! $return) {
+            $return = $event->getResult();
+        }
+        return $return;
+    }
+}

--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -36,6 +36,7 @@ class ServiceListenerFactory implements FactoryInterface
     protected $defaultServiceConfig = [
         'invokables' => [
             'DispatchListener'     => 'Zend\Mvc\DispatchListener',
+            'MiddlewareListener'   => 'Zend\Mvc\MiddlewareListener',
             'RouteListener'        => 'Zend\Mvc\RouteListener',
             'SendResponseListener' => 'Zend\Mvc\SendResponseListener',
             'ViewJsonRenderer'     => 'Zend\View\Renderer\JsonRenderer',

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -166,6 +166,7 @@ class ApplicationTest extends TestCase
         return [
             ['RouteListener', MvcEvent::EVENT_ROUTE, 'onRoute'],
             ['DispatchListener', MvcEvent::EVENT_DISPATCH, 'onDispatch'],
+            ['MiddlewareListener', MvcEvent::EVENT_DISPATCH, 'onDispatch'],
             ['SendResponseListener', MvcEvent::EVENT_FINISH, 'sendResponse'],
             ['ViewManager', MvcEvent::EVENT_BOOTSTRAP, 'onBootstrap'],
             ['HttpMethodListener', MvcEvent::EVENT_ROUTE, 'onRoute'],


### PR DESCRIPTION
**NOTE:** This PR is a WIP, please don't merge it.

This PR adds the middleware support to MVC. We want to be able to dispatch a "middleware" parameter as callable or service, using the signature:

``` php
(
  Psr\Http\Message\ServerRequestInterface $request,
  Psr\Http\Message\ResponseInterface $response
)
```

To do:
- [x] Fix and complete the unit test
