### PR TITLE
Ensure MiddlewareListener tests against abstract factories

### DIFF
--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -48,7 +48,7 @@ class MiddlewareListener extends AbstractListenerAggregate
         $serviceManager = $application->getServiceManager();
         $middlewareName = is_string($middleware) ? $middleware : get_class($middleware);
 
-        if (is_string($middleware) && $serviceManager->has($middleware)) {
+        if (is_string($middleware) && $serviceManager->has($middleware, true)) {
             $middleware = $serviceManager->get($middleware);
         }
         if (! is_callable($middleware)) {

--- a/test/DispatchListenerTest.php
+++ b/test/DispatchListenerTest.php
@@ -43,7 +43,7 @@ class DispatchListenerTest extends TestCase
         return $event;
     }
 
-    public function testControllerLoaderComposedOfAbstractFactory()
+    public function testControllerManagerUsingAbstractFactory()
     {
         $controllerManager = new ControllerManager(new ServiceManager(), ['abstract_factories' => [
             Controller\TestAsset\ControllerLoaderAbstractFactory::class,
@@ -64,7 +64,7 @@ class DispatchListenerTest extends TestCase
         $this->assertSame(200, $return->getStatusCode());
     }
 
-    public function testUnlocatableControllerLoaderComposedOfAbstractFactory()
+    public function testUnlocatableControllerViaAbstractFactory()
     {
         $controllerManager = new ControllerManager(new ServiceManager(), ['abstract_factories' => [
             Controller\TestAsset\UnlocatableControllerLoaderAbstractFactory::class,

--- a/test/TestAsset/Middleware.php
+++ b/test/TestAsset/Middleware.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\TestAsset;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class Middleware
+{
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next = null)
+    {
+        $response->getBody()->write(__CLASS__);
+        return $response;
+    }
+}

--- a/test/TestAsset/MiddlewareAbstractFactory.php
+++ b/test/TestAsset/MiddlewareAbstractFactory.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\TestAsset;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+
+class MiddlewareAbstractFactory implements AbstractFactoryInterface
+{
+    public $classmap = array(
+        'test' => 'ZendTest\Mvc\TestAsset\Middleware',
+    );
+
+    public function canCreateServiceWithName(ContainerInterface $container, $name)
+    {
+        if (! isset($this->classmap[$name])) {
+            return false;
+        }
+
+        $classname = $this->classmap[$name];
+        return class_exists($classname);
+    }
+
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        $classname = $this->classmap[$name];
+        return new $classname;
+    }
+}


### PR DESCRIPTION
zend-servicemanager v3 modified the behavior of `has()` to **not** search abstract factories by default. You can force it to do so by passing an optional second argument, a boolean flag, with a value of boolean true.

The `DispatchListener` was already doing this, but the `MiddlewareListener` was not. This patch adds tests to do so, and updates some mocking assumptions to expect the flag.

Several method names in the `DispatchListener` tests were also updated to clarify the behavior being tested.
