### PR TITLE
Compatibility with latest develop branch of ServiceManager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "zendframework/zend-servicemanager": "dev-develop as 2.6.0",
         "zendframework/zend-hydrator": "~1.0",
         "zendframework/zend-form": "~2.6",
-        "zendframework/zend-stdlib": "~2.7",
+        "zendframework/zend-stdlib": "dev-develop as 2.8.0",
         "zendframework/zend-psr7bridge": "^0.2",
         "container-interop/container-interop": "^1.1"
     },

--- a/src/Application.php
+++ b/src/Application.php
@@ -262,7 +262,7 @@ class Application implements
         $smConfig = new Service\ServiceManagerConfig($smConfig);
 
         $serviceManager = new ServiceManager($smConfig->toArray());
-        $serviceManager = $serviceManager->withConfig(['services' => [
+        $serviceManager = $serviceManager->configure(['services' => [
             'ApplicationConfig' => $configuration,
         ]]);
 

--- a/src/Router/Console/SimpleRouteStack.php
+++ b/src/Router/Console/SimpleRouteStack.php
@@ -27,7 +27,7 @@ class SimpleRouteStack extends BaseSimpleRouteStack
     protected function init()
     {
         $routes = $this->routePluginManager;
-        $this->routePluginManager = $routes->withConfig(['invokables' => [
+        $this->routePluginManager = $routes->configure(['invokables' => [
             'catchall' => __NAMESPACE__ . '\Catchall',
             'simple'   => __NAMESPACE__ . '\Simple',
         ]]);

--- a/src/Router/Http/TreeRouteStack.php
+++ b/src/Router/Http/TreeRouteStack.php
@@ -81,7 +81,7 @@ class TreeRouteStack extends SimpleRouteStack
         $this->prototypes = new ArrayObject;
 
         $routes = $this->routePluginManager;
-        $this->routePluginManager = $routes->withConfig([
+        $this->routePluginManager = $routes->configure([
             'aliases' => [
                 'Chain'    => 'chain',
                 'Hostname' => 'hostname',

--- a/src/Router/RoutePluginManager.php
+++ b/src/Router/RoutePluginManager.php
@@ -65,7 +65,7 @@ class RoutePluginManager extends AbstractPluginManager
      * before passing to the parent.
      *
      * @param array $config
-     * @return void
+     * @return self
      */
     public function configure(array $config)
     {
@@ -86,7 +86,7 @@ class RoutePluginManager extends AbstractPluginManager
             unset($config['invokables']);
         }
 
-        parent::configure($config);
+        return parent::configure($config);
     }
 
      /**

--- a/src/Router/RoutePluginManager.php
+++ b/src/Router/RoutePluginManager.php
@@ -67,7 +67,7 @@ class RoutePluginManager extends AbstractPluginManager
      * @param array $config
      * @return void
      */
-    protected function configure(array $config)
+    public function configure(array $config)
     {
         if (isset($config['invokables']) && ! empty($config['invokables'])) {
             $aliases   = $this->createAliasesForInvokables($config['invokables']);

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -246,6 +246,7 @@ class ApplicationTest extends TestCase
 
     public function setupPathController($addService = true)
     {
+        $this->serviceManager->setAllowOverride(true);
         $request = $this->serviceManager->get('Request');
         $request->setUri('http://example.local/path');
 
@@ -257,7 +258,7 @@ class ApplicationTest extends TestCase
             ],
         ]);
         $router->addRoute('path', $route);
-        $services = $this->serviceManager->withConfig([
+        $services = $this->serviceManager->configure([
             'aliases' => [
                 'Router'     => 'HttpRouter',
             ],
@@ -268,7 +269,7 @@ class ApplicationTest extends TestCase
 
         $application = $this->setApplicationServiceManager($this->application, $services);
         if ($addService) {
-            $services = $services->withConfig(['factories' => [
+            $services = $services->configure(['factories' => [
                 'ControllerManager' => function ($services) {
                     return new ControllerManager($services, ['factories' => [
                         'path' => function () {
@@ -299,7 +300,7 @@ class ApplicationTest extends TestCase
         ]);
         $router->addRoute('sample', $route);
 
-        $services = $this->serviceManager->withConfig(['factories' => [
+        $services = $this->serviceManager->configure(['factories' => [
             'ControllerManager' => function ($services) {
                 return new ControllerManager($services, ['factories' => [
                     'sample' => function () {
@@ -331,7 +332,7 @@ class ApplicationTest extends TestCase
 
         $application = $this->application;
         if ($addService) {
-            $services = $this->serviceManager->withConfig(['factories' => [
+            $services = $this->serviceManager->configure(['factories' => [
                 'ControllerManager' => function ($services) {
                     return new ControllerManager($services, ['factories' => [
                         'bad' => function () {

--- a/test/Controller/Plugin/ForwardTest.php
+++ b/test/Controller/Plugin/ForwardTest.php
@@ -120,7 +120,7 @@ class ForwardTest extends TestCase
 
     public function testDispatchRaisesDomainExceptionIfDiscoveredControllerIsNotDispatchable()
     {
-        $controllers = $this->controllers->withConfig(['factories' => [
+        $controllers = $this->controllers->configure(['factories' => [
             'bogus' => function () {
                 return new stdClass;
             },

--- a/test/Service/ControllerManagerFactoryTest.php
+++ b/test/Service/ControllerManagerFactoryTest.php
@@ -79,7 +79,7 @@ class ControllerManagerFactoryTest extends TestCase
     public function testControllerLoadedCanBeInjectedWithValuesFromPeer()
     {
         $loader = $this->services->get('ControllerManager');
-        $loader = $loader->withConfig(['invokables' => [
+        $loader = $loader->configure(['invokables' => [
             'ZendTest\Dispatchable' => TestAsset\Dispatchable::class,
         ]]);
 
@@ -91,8 +91,9 @@ class ControllerManagerFactoryTest extends TestCase
 
     public function testCallPluginWithControllerPluginManager()
     {
+        $this->services->setAllowOverride(true);
         $controllerPluginManager = $this->services->get('ControllerPluginManager');
-        $controllerPluginManager = $controllerPluginManager->withConfig([
+        $controllerPluginManager = $controllerPluginManager->configure([
             'invokables' => [
                 'samplePlugin' => 'ZendTest\Mvc\Controller\Plugin\TestAsset\SamplePlugin',
             ],
@@ -101,7 +102,7 @@ class ControllerManagerFactoryTest extends TestCase
         $controller    = new \ZendTest\Mvc\Controller\TestAsset\SampleController;
         $controllerPluginManager->setController($controller);
 
-        $services = $this->services->withConfig(['services' => [
+        $services = $this->services->configure(['services' => [
             'ControllerPluginManager' => $controllerPluginManager,
         ]]);
 

--- a/test/Service/ServiceManagerConfigTest.php
+++ b/test/Service/ServiceManagerConfigTest.php
@@ -48,7 +48,7 @@ class ServiceManagerConfigTest extends TestCase
         $events = new EventManager($this->services->get('SharedEventManager'));
         TestAsset\EventManagerAwareObject::$defaultEvents = $events;
 
-        $services = $this->services->withConfig(['invokables' => [
+        $services = $this->services->configure(['invokables' => [
             'EventManagerAwareObject' => TestAsset\EventManagerAwareObject::class,
         ]]);
 

--- a/test/Service/ViewHelperManagerFactoryTest.php
+++ b/test/Service/ViewHelperManagerFactoryTest.php
@@ -49,7 +49,7 @@ class ViewHelperManagerFactoryTest extends TestCase
      */
     public function testDoctypeFactoryDoesNotRaiseErrorOnMissingConfiguration($config)
     {
-        $services = $this->services->withConfig(['services' => [
+        $services = $this->services->configure(['services' => [
             'config' => $config,
         ]]);
         $manager = $this->factory->__invoke($services, 'ViewHelperManager');
@@ -60,7 +60,7 @@ class ViewHelperManagerFactoryTest extends TestCase
 
     public function testConsoleRequestsResultInSilentFailure()
     {
-        $services = $this->services->withConfig(['services' => [
+        $services = $this->services->configure(['services' => [
             'config'  => [],
             'Request' => new ConsoleRequest(),
         ]]);
@@ -88,7 +88,7 @@ class ViewHelperManagerFactoryTest extends TestCase
             $this->markTestSkipped('Cannot force console context; skipping test');
         }
 
-        $services = $this->services->withConfig(['services' => [
+        $services = $this->services->configure(['services' => [
             'config' => [
                 'view_manager' => [
                     'base_path_console' => 'http://test.com',

--- a/test/View/Console/ViewManagerTest.php
+++ b/test/View/Console/ViewManagerTest.php
@@ -124,7 +124,7 @@ class ViewManagerTest extends TestCase
         $request      = new ConsoleRequest();
         $response     = new ConsoleResponse();
 
-        $services = $this->services->withConfig(['services' => [
+        $services = $this->services->configure(['services' => [
             'config'       => $config,
             'Request'      => $request,
             'EventManager' => $eventManager,
@@ -152,7 +152,7 @@ class ViewManagerTest extends TestCase
         $request      = new ConsoleRequest();
         $response     = new ConsoleResponse();
 
-        $services = $this->services->withConfig([
+        $services = $this->services->configure([
             'services' => [
                 'config'       => [],
                 'Request'      => $request,


### PR DESCRIPTION
This pull requests fixes compatibility with latest ServiceManager, and ensures test suite passes.
- built on top of Samsonasik's changes, replaces #47
- `RoutePluginManager::configure` returns `$this`, in order to match with parent signature;
- **note**: for test suite to pass, [this pull request](https://github.com/zendframework/zend-modulemanager/pull/26) to module manager must be merged first
