### PR TITLE
[application] Remove unused attribute configuration

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -54,11 +54,6 @@ class Application implements
     const ERROR_ROUTER_NO_MATCH            = 'error-router-no-match';
 
     /**
-     * @var array
-     */
-    protected $configuration = null;
-
-    /**
      * Default application event listeners
      *
      * @var array
@@ -100,12 +95,11 @@ class Application implements
     /**
      * Constructor
      *
-     * @param mixed $configuration
+     * @param null $configuration. To be removed on future releases
      * @param ServiceManager $serviceManager
      */
     public function __construct($configuration, ServiceManager $serviceManager)
     {
-        $this->configuration  = $configuration;
         $this->serviceManager = $serviceManager;
 
         $this->setEventManager($serviceManager->get('EventManager'));

--- a/src/Service/ApplicationFactory.php
+++ b/src/Service/ApplicationFactory.php
@@ -26,6 +26,6 @@ class ApplicationFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return new Application($serviceLocator->get('Config'), $serviceLocator);
+        return new Application(null, $serviceLocator);
     }
 }

--- a/test/View/Console/ViewManagerTest.php
+++ b/test/View/Console/ViewManagerTest.php
@@ -117,7 +117,7 @@ class ViewManagerTest extends TestCase
 
         $manager = $this->factory->createService($this->services);
 
-        $application = new Application($config, $this->services);
+        $application = new Application(null, $this->services);
 
         $event = new MvcEvent();
         $event->setApplication($application);
@@ -142,7 +142,7 @@ class ViewManagerTest extends TestCase
 
         $manager = $this->factory->createService($this->services);
 
-        $application = new Application([], $this->services);
+        $application = new Application(null, $this->services);
 
         $event = new MvcEvent();
         $event->setApplication($application);

--- a/test/View/DefaultRendereringStrategyTest.php
+++ b/test/View/DefaultRendereringStrategyTest.php
@@ -148,7 +148,7 @@ class DefaultRendereringStrategyTest extends TestCase
             return $events;
         }, false);
 
-        $application = new Application([], $services);
+        $application = new Application(null, $services);
         $this->event->setApplication($application);
 
         $test = (object) ['flag' => false];


### PR DESCRIPTION
Parameter is keep on constructor for backward compatibility
