### PR TITLE
[application] Safe retrieve of request service

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -12,6 +12,7 @@ namespace Zend\Mvc;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\ServiceManager\ServiceManager;
+use Zend\Stdlib\RequestInterface;
 use Zend\Stdlib\ResponseInterface;
 
 /**
@@ -83,19 +84,19 @@ class Application implements
     protected $events;
 
     /**
-     * @var \Zend\Stdlib\RequestInterface
+     * @var null|RequestInterface
      */
-    protected $request;
+    private $request;
 
     /**
-     * @var ResponseInterface
+     * @var null|ResponseInterface
      */
-    protected $response;
+    private $response;
 
     /**
      * @var ServiceManager
      */
-    protected $serviceManager = null;
+    private $serviceManager;
 
     /**
      * Constructor
@@ -109,9 +110,6 @@ class Application implements
         $this->serviceManager = $serviceManager;
 
         $this->setEventManager($serviceManager->get('EventManager'));
-
-        $this->request        = $serviceManager->get('Request');
-        $this->response       = $serviceManager->get('Response');
     }
 
     /**
@@ -149,8 +147,8 @@ class Application implements
         $this->event = $event  = new MvcEvent();
         $event->setTarget($this);
         $event->setApplication($this)
-              ->setRequest($this->request)
-              ->setResponse($this->response)
+              ->setRequest($this->getRequest())
+              ->setResponse($this->getResponse())
               ->setRouter($serviceManager->get('Router'));
 
         // Trigger bootstrap events
@@ -159,9 +157,7 @@ class Application implements
     }
 
     /**
-     * Retrieve the service manager
-     *
-     * @return ServiceManager
+     * {@inheritdoc}
      */
     public function getServiceManager()
     {
@@ -169,22 +165,26 @@ class Application implements
     }
 
     /**
-     * Get the request object
-     *
-     * @return \Zend\Stdlib\RequestInterface
+     * {@inheritdoc}
      */
     public function getRequest()
     {
+        if (!$this->request) {
+            $this->request = $this->serviceManager->get('Request');
+        }
+
         return $this->request;
     }
 
     /**
-     * Get the response object
-     *
-     * @return ResponseInterface
+     * {@inheritdoc}
      */
     public function getResponse()
     {
+        if (!$this->response) {
+            $this->response = $this->serviceManager->get('Response');
+        }
+
         return $this->response;
     }
 


### PR DESCRIPTION
Request service is made with data from external input (like browser data or command line arguments)

If the input is malformed (accidentally or intentionally) the Request service cannot be created and a non catched exception is throw killing the application.
