### PR TITLE
Use the HydratorPluginManager from zend-stdlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "zendframework/zend-eventmanager": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-hydrator": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-hydrator": "~1.0",
         "zendframework/zend-form": "~2.6",
-        "zendframework/zend-stdlib": "~2.7"
+        "zendframework/zend-stdlib": "^2.7.5"
     },
     "require-dev": {
         "zendframework/zend-authentication": "~2.5",

--- a/src/Service/HydratorManagerFactory.php
+++ b/src/Service/HydratorManagerFactory.php
@@ -11,5 +11,8 @@ namespace Zend\Mvc\Service;
 
 class HydratorManagerFactory extends AbstractPluginManagerFactory
 {
+    /**
+     * @todo Switch to Zend\Hydrator\HydratorPluginManager for 3.0 (if kept)
+     */
     const PLUGIN_MANAGER_CLASS = 'Zend\Stdlib\Hydrator\HydratorPluginManager';
 }

--- a/src/Service/HydratorManagerFactory.php
+++ b/src/Service/HydratorManagerFactory.php
@@ -11,5 +11,5 @@ namespace Zend\Mvc\Service;
 
 class HydratorManagerFactory extends AbstractPluginManagerFactory
 {
-    const PLUGIN_MANAGER_CLASS = 'Zend\Hydrator\HydratorPluginManager';
+    const PLUGIN_MANAGER_CLASS = 'Zend\Stdlib\Hydrator\HydratorPluginManager';
 }

--- a/test/Service/HydratorManagerFactoryTest.php
+++ b/test/Service/HydratorManagerFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Hydrator\HydratorPluginManager as ZendHydratorManager;
+use Zend\Mvc\Service\HydratorManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Stdlib\Hydrator\HydratorPluginManager;
+
+class HydratorManagerFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->factory = new HydratorManagerFactory();
+        $this->services = $this->prophesize(ServiceLocatorInterface::class);
+        $this->services->get('Config')->willReturn([]);
+    }
+
+    public function testFactoryReturnsZendHydratorManagerInstance()
+    {
+        $hydrators = $this->factory->createService($this->services->reveal());
+        $this->assertInstanceOf(ZendHydratorManager::class, $hydrators);
+        return $hydrators;
+    }
+
+    /**
+     * @todo Remove for 3.0
+     * @depends testFactoryReturnsZendHydratorManagerInstance
+     */
+    public function testFactoryReturnsStdlibHydratorManagerInstance($hydrators)
+    {
+        $this->assertInstanceOf(HydratorPluginManager::class, $hydrators);
+    }
+}


### PR DESCRIPTION
For backwards compatibility. Essentially reverts #30, but requires zend-stdlib 2.7.5 or higher to ensure backwards compat.

Fixes zendframework/zf2#7672
