### PR TITLE
Fixed BC break with zend-view 2.6

### DIFF
--- a/src/Service/ViewHelperManagerFactory.php
+++ b/src/Service/ViewHelperManagerFactory.php
@@ -41,7 +41,16 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $plugins = parent::createService($serviceLocator);
+        $pluginManagerClass = static::PLUGIN_MANAGER_CLASS;
+        /* @var $plugins AbstractPluginManager */
+        $plugins = new $pluginManagerClass($serviceLocator);
+        $plugins->setServiceLocator($serviceLocator);
+        $configuration = $serviceLocator->get('Config');
+
+        if (isset($configuration['di']) && $serviceLocator->has('Di')) {
+            $plugins->addAbstractFactory($serviceLocator->get('DiAbstractServiceFactory'));
+        }
+
 
         foreach ($this->defaultHelperMapClasses as $configClass) {
             if (is_string($configClass) && class_exists($configClass)) {


### PR DESCRIPTION
Reference with https://github.com/zendframework/zend-view/issues/43

I remove  the parent constructor because the `Zend\Hydrator` plugin manager is not ready to support SM v3
# Try it

If you are interested to test this first patch
https://github.com/zendframework/zend-mvc/pull/70

``` json
{
    "repositories": [
        {
             "type": "vcs",
             "url": "git@github.com:gianarb/zend-mvc"
        }
    ],
    "require": {
        "zendframework/zend-mvc": "2.6.0 as dev-hotfix/bc-break-view
   }
}
```
