### PR TITLE
Ensure console (and controller!) usage works for v2 applications

### DIFF
--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -17,7 +17,6 @@ use Zend\Http\PhpEnvironment\Response as HttpResponse;
 use Zend\Http\Request as HttpRequest;
 use Zend\Mvc\InjectApplicationEventInterface;
 use Zend\Mvc\MvcEvent;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\DispatchableInterface as Dispatchable;
@@ -47,8 +46,7 @@ use Zend\Stdlib\ResponseInterface as Response;
 abstract class AbstractController implements
     Dispatchable,
     EventManagerAwareInterface,
-    InjectApplicationEventInterface,
-    ServiceLocatorAwareInterface
+    InjectApplicationEventInterface
 {
     /**
      * @var PluginManager

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -17,6 +17,8 @@ use Zend\Http\PhpEnvironment\Response as HttpResponse;
 use Zend\Http\Request as HttpRequest;
 use Zend\Mvc\InjectApplicationEventInterface;
 use Zend\Mvc\MvcEvent;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\DispatchableInterface as Dispatchable;
 use Zend\Stdlib\RequestInterface as Request;
@@ -45,7 +47,8 @@ use Zend\Stdlib\ResponseInterface as Response;
 abstract class AbstractController implements
     Dispatchable,
     EventManagerAwareInterface,
-    InjectApplicationEventInterface
+    InjectApplicationEventInterface,
+    ServiceLocatorAwareInterface
 {
     /**
      * @var PluginManager
@@ -61,6 +64,11 @@ abstract class AbstractController implements
      * @var Response
      */
     protected $response;
+
+    /**
+     * @var ServiceLocatorInterface
+     */
+    protected $serviceLocator;
 
     /**
      * @var Event
@@ -222,6 +230,27 @@ abstract class AbstractController implements
         }
 
         return $this->event;
+    }
+
+    /**
+     * Set serviceManager instance
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return void
+     */
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    /**
+     * Retrieve serviceManager instance
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceLocator()
+    {
+        return $this->serviceLocator;
     }
 
     /**

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -54,8 +54,11 @@ class ControllerManager extends AbstractPluginManager
         $this->addInitializer([$this, 'injectEventManager']);
         $this->addInitializer([$this, 'injectConsole']);
         $this->addInitializer([$this, 'injectPluginManager']);
-        $this->addInitializer([$this, 'injectServiceLocator']);
         parent::__construct($configOrContainerInstance, $v3config);
+
+        // Added after parent construction, as v2 abstract plugin managers add
+        // one during construction.
+        $this->addInitializer([$this, 'injectServiceLocator']);
     }
 
     /**
@@ -204,6 +207,7 @@ class ControllerManager extends AbstractPluginManager
      */
     public function injectServiceLocator($first, $second)
     {
+        printf("In %s\n", __METHOD__);
         if ($first instanceof ContainerInterface) {
             $container = $first;
             $controller = $second;
@@ -217,7 +221,7 @@ class ControllerManager extends AbstractPluginManager
             $container = $container->getServiceLocator() ?: $container;
         }
 
-        if (! interface_exists(ServiceLocatorAwareInterface::class)
+        if (! $controller instanceof ServiceLocatorAwareInterface
             && method_exists($controller, 'setServiceLocator')
         ) {
             trigger_error(sprintf(

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -217,6 +217,18 @@ class ControllerManager extends AbstractPluginManager
             $container = $container->getServiceLocator() ?: $container;
         }
 
+        if (! interface_exists(ServiceLocatorAwareInterface::class)
+            && method_exists($controller, 'setServiceLocator')
+        ) {
+            trigger_error(sprintf(
+                'ServiceLocatorAwareInterface is deprecated and will be removed in version 3.0, along '
+                . 'with the ServiceLocatorAwareInitializer. Please update your class %s to remove '
+                . 'the implementation, and start injecting your dependencies via factory instead.',
+                get_class($controller)
+            ), E_USER_DEPRECATED);
+            $controller->setServiceLocator($container);
+        }
+
         if ($controller instanceof ServiceLocatorAwareInterface) {
             trigger_error(sprintf(
                 'ServiceLocatorAwareInterface is deprecated and will be removed in version 3.0, along '

--- a/src/Router/Console/SimpleRouteStack.php
+++ b/src/Router/Console/SimpleRouteStack.php
@@ -42,8 +42,8 @@ class SimpleRouteStack extends BaseSimpleRouteStack
                 Simple::class   => RouteInvokableFactory::class,
 
                 // v2 normalized names
-                'zendmvcrouterconsoleCatchall' => RouteInvokableFactory::class,
-                'zendmvcrouterconsoleSimple'   => RouteInvokableFactory::class,
+                'zendmvcrouterconsolecatchall' => RouteInvokableFactory::class,
+                'zendmvcrouterconsolesimple'   => RouteInvokableFactory::class,
             ],
         ]))->configureServiceManager($this->routePluginManager);
     }
@@ -79,19 +79,21 @@ class SimpleRouteStack extends BaseSimpleRouteStack
     {
         if ($specs instanceof Traversable) {
             $specs = ArrayUtils::iteratorToArray($specs);
-        } elseif (!is_array($specs)) {
+        }
+        
+        if (! is_array($specs)) {
             throw new Exception\InvalidArgumentException('Route definition must be an array or Traversable object');
         }
 
         // default to 'simple' console route
-        if (!isset($specs['type'])) {
-            $specs['type'] = 'simple';
+        if (! isset($specs['type'])) {
+            $specs['type'] = Simple::class;
         }
 
         // build route object
         $route = parent::routeFromArray($specs);
 
-        if (!$route instanceof RouteInterface) {
+        if (! $route instanceof RouteInterface) {
             throw new Exception\RuntimeException('Given route does not implement Console route interface');
         }
 

--- a/src/Router/Console/SimpleRouteStack.php
+++ b/src/Router/Console/SimpleRouteStack.php
@@ -80,7 +80,7 @@ class SimpleRouteStack extends BaseSimpleRouteStack
         if ($specs instanceof Traversable) {
             $specs = ArrayUtils::iteratorToArray($specs);
         }
-        
+
         if (! is_array($specs)) {
             throw new Exception\InvalidArgumentException('Route definition must be an array or Traversable object');
         }

--- a/src/Service/RouterFactory.php
+++ b/src/Service/RouterFactory.php
@@ -46,10 +46,16 @@ class RouterFactory implements FactoryInterface
      * For use with zend-servicemanager v2; proxies to __invoke().
      *
      * @param ServiceLocatorInterface $container
+     * @param null|string $normalizedName
+     * @param null|string $requestedName
      * @return RouteStackInterface
      */
-    public function createService(ServiceLocatorInterface $container)
+    public function createService(ServiceLocatorInterface $container, $normalizedName = null, $requestedName = null)
     {
-        return $this($container, RouteStackInterface::class);
+        if ($normalizedName === 'router' && Console::isConsole()) {
+            $requestedName = 'ConsoleRouter';
+        }
+
+        return $this($container, $requestedName);
     }
 }

--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -40,6 +40,7 @@ class ServiceListenerFactory implements FactoryInterface
         'aliases' => [
             'Configuration'                              => 'config',
             'configuration'                              => 'config',
+            'console'                                    => 'ConsoleAdapter',
             'Console'                                    => 'ConsoleAdapter',
             'ConsoleDefaultRenderingStrategy'            => View\Console\DefaultRenderingStrategy::class,
             'ControllerLoader'                           => 'ControllerManager',

--- a/src/Service/ServiceManagerConfig.php
+++ b/src/Service/ServiceManagerConfig.php
@@ -141,6 +141,18 @@ class ServiceManagerConfig extends Config
                     ), E_USER_DEPRECATED);
                     $instance->setServiceLocator($container);
                 }
+
+                if (! interface_exists(ServiceLocatorAwareInterface::class)
+                    && method_exists($instance, 'setServiceLocator')
+                ) {
+                    trigger_error(sprintf(
+                        'ServiceLocatorAwareInterface is deprecated and will be removed in version 3.0, along '
+                        . 'with the ServiceLocatorAwareInitializer. Please update your class %s to remove '
+                        . 'the implementation, and start injecting your dependencies via factory instead.',
+                        get_class($instance)
+                    ), E_USER_DEPRECATED);
+                    $instance->setServiceLocator($container);
+                }
             },
         ]);
 

--- a/src/Service/ServiceManagerConfig.php
+++ b/src/Service/ServiceManagerConfig.php
@@ -142,7 +142,7 @@ class ServiceManagerConfig extends Config
                     $instance->setServiceLocator($container);
                 }
 
-                if (! interface_exists(ServiceLocatorAwareInterface::class)
+                if (! $instance instanceof ServiceLocatorAwareInterface
                     && method_exists($instance, 'setServiceLocator')
                 ) {
                     trigger_error(sprintf(

--- a/test/Application/AllowsReturningEarlyFromRoutingTest.php
+++ b/test/Application/AllowsReturningEarlyFromRoutingTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Mvc\Application;
 
+use PHPUnit_Framework_Error_Deprecated;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Http\PhpEnvironment\Response;
 use Zend\Mvc\MvcEvent;
@@ -16,6 +17,12 @@ use Zend\Mvc\MvcEvent;
 class AllowsReturningEarlyFromRoutingTest extends TestCase
 {
     use PathControllerTrait;
+
+    public function setUp()
+    {
+        // Ignore deprecation errors
+        PHPUnit_Framework_Error_Deprecated::$enabled = false;
+    }
 
     public function testAllowsReturningEarlyFromRouting()
     {

--- a/test/Application/ControllerIsDispatchedTest.php
+++ b/test/Application/ControllerIsDispatchedTest.php
@@ -9,12 +9,19 @@
 
 namespace ZendTest\Mvc\Application;
 
+use PHPUnit_Framework_Error_Deprecated;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Mvc\MvcEvent;
 
 class ControllerIsDispatchedTest extends TestCase
 {
     use PathControllerTrait;
+
+    public function setUp()
+    {
+        // Ignore deprecation errors
+        PHPUnit_Framework_Error_Deprecated::$enabled = false;
+    }
 
     public function testControllerIsDispatchedDuringRun()
     {

--- a/test/Application/ExceptionsRaisedInDispatchableShouldRaiseDispatchErrorEventTest.php
+++ b/test/Application/ExceptionsRaisedInDispatchableShouldRaiseDispatchErrorEventTest.php
@@ -9,12 +9,19 @@
 
 namespace ZendTest\Mvc\Application;
 
+use PHPUnit_Framework_Error_Deprecated;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Mvc\MvcEvent;
 
 class ExceptionsRaisedInDispatchableShouldRaiseDispatchErrorEventTest extends TestCase
 {
     use BadControllerTrait;
+
+    public function setUp()
+    {
+        // Ignore deprecation errors
+        PHPUnit_Framework_Error_Deprecated::$enabled = false;
+    }
 
     /**
      * @group error-handling

--- a/test/Controller/IntegrationTest.php
+++ b/test/Controller/IntegrationTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Mvc\Controller;
 
+use PHPUnit_Framework_Error_Deprecated;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\SharedEventManager;
@@ -21,6 +22,9 @@ class IntegrationTest extends TestCase
 {
     public function setUp()
     {
+        // Ignore deprecation errors
+        PHPUnit_Framework_Error_Deprecated::$enabled = false;
+
         $this->sharedEvents = new SharedEventManager();
 
         $this->services = new ServiceManager();

--- a/test/Controller/Plugin/ForwardTest.php
+++ b/test/Controller/Plugin/ForwardTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Mvc\Controller\Plugin;
 
+use PHPUnit_Framework_Error_Deprecated;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionClass;
 use stdClass;
@@ -51,6 +52,9 @@ class ForwardTest extends TestCase
 
     public function setUp()
     {
+        // Ignore deprecation errors
+        PHPUnit_Framework_Error_Deprecated::$enabled = false;
+
         $eventManager = $this->createEventManager(new SharedEventManager());
         $mockApplication = $this->getMock('Zend\Mvc\ApplicationInterface');
         $mockApplication->expects($this->any())->method('getEventManager')->will($this->returnValue($eventManager));

--- a/test/Router/Console/SimpleRouteStackTest.php
+++ b/test/Router/Console/SimpleRouteStackTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-mvc for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Router\Console;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionClass;
+use Zend\Mvc\Router\Console\Catchall;
+use Zend\Mvc\Router\Console\Simple;
+use Zend\Mvc\Router\Console\SimpleRouteStack;
+use Zend\ServiceManager\ServiceManager;
+
+class SimpleRouteStackTest extends TestCase
+{
+    public function routeTypeProvider()
+    {
+        $catchallOpts = ['defaults' => []];
+        $simpleOpts   = ['route' => 'test'];
+
+        $data = [
+            'catchall' => ['catchall', $catchallOpts, Catchall::class],
+            'catchAll' => ['catchAll', $catchallOpts, Catchall::class],
+            'Catchall' => ['Catchall', $catchallOpts, Catchall::class],
+            'CatchAll' => ['CatchAll', $catchallOpts, Catchall::class],
+            'simple'   => ['simple', $simpleOpts, Simple::class],
+            'Simple'   => ['Simple', $simpleOpts, Simple::class],
+
+            Catchall::class => [Catchall::class, $catchallOpts, Catchall::class],
+            Simple::class   => [Simple::class, $simpleOpts, Simple::class],
+        ];
+
+        // Two additional cases under zend-servicemanager v2:
+        $r = new ReflectionClass(ServiceManager::class);
+        if (! $r->hasMethod('configure')) {
+            $data['zendmvcrouterconsolecatchall'] = ['zendmvcrouterconsolecatchall', $catchallOpts, Catchall::class];
+            $data['zendmvcrouterconsolesimple']   = ['zendmvcrouterconsolesimple', $simpleOpts, Simple::class];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider routeTypeProvider
+     */
+    public function testExpectedAliasesAndFactoriesResolve($serviceName, array $options, $expected)
+    {
+        $router = new SimpleRouteStack();
+        $routes = $router->getRoutePluginManager();
+        $this->assertInstanceOf($expected, $routes->get($serviceName, $options));
+    }
+}

--- a/test/Router/Console/SimpleRouteStackTest.php
+++ b/test/Router/Console/SimpleRouteStackTest.php
@@ -13,7 +13,6 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Mvc\Router\Console\Catchall;
 use Zend\Mvc\Router\Console\Simple;
 use Zend\Mvc\Router\Console\SimpleRouteStack;
-use Zend\ServiceManager\ServiceManager;
 
 class SimpleRouteStackTest extends TestCase
 {

--- a/test/Router/Console/SimpleRouteStackTest.php
+++ b/test/Router/Console/SimpleRouteStackTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Mvc\Router\Console;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use ReflectionClass;
 use Zend\Mvc\Router\Console\Catchall;
 use Zend\Mvc\Router\Console\Simple;
 use Zend\Mvc\Router\Console\SimpleRouteStack;
@@ -23,7 +22,7 @@ class SimpleRouteStackTest extends TestCase
         $catchallOpts = ['defaults' => []];
         $simpleOpts   = ['route' => 'test'];
 
-        $data = [
+        return [
             'catchall' => ['catchall', $catchallOpts, Catchall::class],
             'catchAll' => ['catchAll', $catchallOpts, Catchall::class],
             'Catchall' => ['Catchall', $catchallOpts, Catchall::class],
@@ -34,15 +33,6 @@ class SimpleRouteStackTest extends TestCase
             Catchall::class => [Catchall::class, $catchallOpts, Catchall::class],
             Simple::class   => [Simple::class, $simpleOpts, Simple::class],
         ];
-
-        // Two additional cases under zend-servicemanager v2:
-        $r = new ReflectionClass(ServiceManager::class);
-        if (! $r->hasMethod('configure')) {
-            $data['zendmvcrouterconsolecatchall'] = ['zendmvcrouterconsolecatchall', $catchallOpts, Catchall::class];
-            $data['zendmvcrouterconsolesimple']   = ['zendmvcrouterconsolesimple', $simpleOpts, Simple::class];
-        }
-
-        return $data;
     }
 
     /**

--- a/test/Service/ControllerManagerFactoryTest.php
+++ b/test/Service/ControllerManagerFactoryTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Mvc\Service;
 
+use PHPUnit_Framework_Error_Deprecated;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\EventManager\SharedEventManager;
 use Zend\Mvc\Service\ControllerManagerFactory;
@@ -34,6 +35,9 @@ class ControllerManagerFactoryTest extends TestCase
 
     public function setUp()
     {
+        // Ignore deprecation errors
+        PHPUnit_Framework_Error_Deprecated::$enabled = false;
+
         $loaderFactory  = new ControllerManagerFactory();
         $this->defaultServiceConfig = [
             'aliases' => [

--- a/test/Service/RouterFactoryTest.php
+++ b/test/Service/RouterFactoryTest.php
@@ -19,6 +19,8 @@ use Zend\ServiceManager\ServiceManager;
 
 class RouterFactoryTest extends TestCase
 {
+    use FactoryEnvironmentTrait;
+
     public function setUp()
     {
         $this->defaultServiceConfig = [
@@ -68,6 +70,17 @@ class RouterFactoryTest extends TestCase
         $config->configureServiceManager($services);
 
         $router = $this->factory->__invoke($services, 'router');
+        $this->assertInstanceOf('Zend\Mvc\Router\Console\SimpleRouteStack', $router);
+    }
+
+    public function testFactoryWillCreateConsoleRouterBasedOnConsoleUsageUnderServiceManagerV2()
+    {
+        $this->setConsoleEnvironment(true);
+
+        $services = new ServiceManager();
+        (new Config($this->defaultServiceConfig))->configureServiceManager($services);
+
+        $router = $this->factory->createService($services, 'router');
         $this->assertInstanceOf('Zend\Mvc\Router\Console\SimpleRouteStack', $router);
     }
 }

--- a/test/Service/ServiceListenerFactoryTest.php
+++ b/test/Service/ServiceListenerFactoryTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Mvc\Service;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
 use Zend\Mvc\Service\ServiceListenerFactory;
 
 class ServiceListenerFactoryTest extends TestCase
@@ -178,5 +179,16 @@ class ServiceListenerFactoryTest extends TestCase
                  ->will($this->returnValue($config));
 
         $this->factory->__invoke($this->sm, 'ServiceListener');
+    }
+
+    public function testDefinesExpectedAliasesForConsole()
+    {
+        $r = new ReflectionProperty($this->factory, 'defaultServiceConfig');
+        $r->setAccessible(true);
+        $config = $r->getValue($this->factory);
+
+        $this->assertArrayHasKey('aliases', $config, 'Missing aliases from default service config');
+        $this->assertArrayHasKey('console', $config['aliases'], 'Missing "console" alias from default service config');
+        $this->assertArrayHasKey('Console', $config['aliases'], 'Missing "Console" alias from default service config');
     }
 }

--- a/test/Service/ServiceManagerConfigTest.php
+++ b/test/Service/ServiceManagerConfigTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Mvc\Service;
 
+use PHPUnit_Framework_Error_Deprecated;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionClass;
 use stdClass;
@@ -37,6 +38,9 @@ class ServiceManagerConfigTest extends TestCase
      */
     protected function setUp()
     {
+        // Disable deprecation notices
+        PHPUnit_Framework_Error_Deprecated::$enabled = false;
+
         $this->config   = new ServiceManagerConfig();
         $this->services = new ServiceManager();
         $this->config->configureServiceManager($this->services);
@@ -211,5 +215,17 @@ class ServiceManagerConfigTest extends TestCase
         $instance->expects($this->never())->method('setEventManager');
 
         $serviceManager->get('EventManagerAware');
+    }
+
+    public function testServiceLocatorAwareInitializerInjectsDuckTypedImplementations()
+    {
+        $serviceManager = new ServiceManager(['factories' => [
+            TestAsset\DuckTypedServiceLocatorAware::class => InvokableFactory::class,
+        ]]);
+        (new ServiceManagerConfig())->configureServiceManager($serviceManager);
+
+        $instance = $serviceManager->get(TestAsset\DuckTypedServiceLocatorAware::class);
+        $this->assertInstanceOf(TestAsset\DuckTypedServiceLocatorAware::class, $instance);
+        $this->assertSame($serviceManager, $instance->getServiceLocator());
     }
 }

--- a/test/Service/ServiceManagerConfigTest.php
+++ b/test/Service/ServiceManagerConfigTest.php
@@ -219,10 +219,10 @@ class ServiceManagerConfigTest extends TestCase
 
     public function testServiceLocatorAwareInitializerInjectsDuckTypedImplementations()
     {
-        $serviceManager = new ServiceManager(['factories' => [
+        $serviceManager = new ServiceManager();
+        (new ServiceManagerConfig(['factories' => [
             TestAsset\DuckTypedServiceLocatorAware::class => InvokableFactory::class,
-        ]]);
-        (new ServiceManagerConfig())->configureServiceManager($serviceManager);
+        ]]))->configureServiceManager($serviceManager);
 
         $instance = $serviceManager->get(TestAsset\DuckTypedServiceLocatorAware::class);
         $this->assertInstanceOf(TestAsset\DuckTypedServiceLocatorAware::class, $instance);

--- a/test/Service/TestAsset/DuckTypedServiceLocatorAware.php
+++ b/test/Service/TestAsset/DuckTypedServiceLocatorAware.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-mvc for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Service\TestAsset;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class DuckTypedServiceLocatorAware
+{
+    private $container;
+
+    public function setServiceLocator(ServiceLocatorInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function getServiceLocator()
+    {
+        return $this->container;
+    }
+}

--- a/test/Service/TestAsset/DuckTypedServiceLocatorAwareController.php
+++ b/test/Service/TestAsset/DuckTypedServiceLocatorAwareController.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-mvc for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Service\TestAsset;
+
+use Zend\Stdlib\DispatchableInterface;
+use Zend\Stdlib\RequestInterface;
+use Zend\Stdlib\ResponseInterface;
+
+class DuckTypedServiceLocatorAwareController extends DuckTypedServiceLocatorAware implements
+    DispatchableInterface
+{
+    public function dispatch(RequestInterface $request, ResponseInterface $response = null)
+    {
+    }
+}


### PR DESCRIPTION
This patch is a result of testing the develop branch against Apigility. The only major show-stopper issue I ran across was with console usage, and this patch provides fixes as follows:
- Aliases `console` to `ConsoleAdapter`, to ensure retrieval can occur under that name.
- Updates the `RouterFactory::createService()` method to test for `Console::isConsole()` and, if true, to set the `$requestedName` passed to `__invoke()` to `ConsoleRouter`. This ensures that the console router can be selected and used at runtime!
- Re-implements the `ServiceLocatorAwareInterface` implementation in `AbstractController`. It was removed originally when we were targeting a v3 release on the develop branch; now that we're targeting v2.7, it needs to be re-introduced.
- Related, re-implemented a `ServiceLocatorAwareInterface` initializer in the `ControllerManager` to ensure the application container is injected.

~~At this point all testing has been integration testing; I'll add tests for this behavior shortly.~~
