### PR TITLE
Continue fixing service casing issues

### DIFF
--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -65,6 +65,7 @@ class ServiceListenerFactory implements FactoryInterface
         'invokables' => [],
         'factories'  => [
             'Application'                    => 'Zend\Mvc\Service\ApplicationFactory',
+            'application'                    => 'Zend\Mvc\Service\ApplicationFactory',
             'config'                         => 'Zend\Mvc\Service\ConfigFactory',
             'ControllerManager'              => 'Zend\Mvc\Service\ControllerManagerFactory',
             'ControllerPluginManager'        => 'Zend\Mvc\Service\ControllerPluginManagerFactory',

--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -10,8 +10,11 @@
 namespace Zend\Mvc\Service;
 
 use Interop\Container\ContainerInterface;
+use ReflectionClass;
+use Zend\Config\Config;
 use Zend\ModuleManager\Listener\ServiceListener;
 use Zend\ModuleManager\Listener\ServiceListenerInterface;
+use Zend\Mvc\Application;
 use Zend\Mvc\View;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\FactoryInterface;
@@ -38,8 +41,8 @@ class ServiceListenerFactory implements FactoryInterface
      */
     protected $defaultServiceConfig = [
         'aliases' => [
-            'Configuration'                              => 'config',
             'configuration'                              => 'config',
+            'Configuration'                              => 'config',
             'console'                                    => 'ConsoleAdapter',
             'Console'                                    => 'ConsoleAdapter',
             'ConsoleDefaultRenderingStrategy'            => View\Console\DefaultRenderingStrategy::class,
@@ -65,8 +68,7 @@ class ServiceListenerFactory implements FactoryInterface
         ],
         'invokables' => [],
         'factories'  => [
-            'Application'                    => 'Zend\Mvc\Service\ApplicationFactory',
-            'application'                    => 'Zend\Mvc\Service\ApplicationFactory',
+            'Application'                    => ApplicationFactory::class,
             'config'                         => 'Zend\Mvc\Service\ConfigFactory',
             'ControllerManager'              => 'Zend\Mvc\Service\ControllerManagerFactory',
             'ControllerPluginManager'        => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
@@ -121,6 +123,20 @@ class ServiceListenerFactory implements FactoryInterface
             'Zend\Form\FormAbstractServiceFactory',
         ],
     ];
+
+    /**
+     * Constructor
+     *
+     * When executed under zend-servicemanager v3, injects additional aliases
+     * to ensure backwards compatibility.
+     */
+    public function __construct()
+    {
+        $r = new ReflectionClass(ServiceLocatorInterface::class);
+        if ($r->hasMethod('build')) {
+            $this->injectV3Aliases();
+        }
+    }
 
     /**
      * Create the service listener service
@@ -275,5 +291,24 @@ class ServiceListenerFactory implements FactoryInterface
                 gettype($options['method'])
             ));
         }
+    }
+
+    /**
+     * Inject additional aliases for zend-servicemanager v3 usage
+     *
+     * If the constructor detects that we're operating under zend-servicemanager v3,
+     * this method injects additional aliases to ensure that common services
+     * can be retrieved using both Titlecase and lowercase, and will get the
+     * same instances.
+     *
+     * @return void
+     */
+    private function injectV3Aliases()
+    {
+        $this->defaultServiceConfig['aliases']['application'] = 'Application';
+        $this->defaultServiceConfig['aliases']['Config']      = 'config';
+        $this->defaultServiceConfig['aliases']['request']     = 'Request';
+        $this->defaultServiceConfig['aliases']['response']    = 'Response';
+        $this->defaultServiceConfig['aliases']['router']      = 'Router';
     }
 }

--- a/src/Service/ViewHelperManagerFactory.php
+++ b/src/Service/ViewHelperManagerFactory.php
@@ -129,11 +129,6 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
     private function createUrlHelperFactory(ContainerInterface $services)
     {
         return function () use ($services) {
-            // zend-servicemanager v2: fetch parent locator
-            if (method_exists($services, 'getServiceLocator') && ! method_exists($services, 'configure')) {
-                $services = $services->getServiceLocator() ?: $services;
-            }
-
             $helper = new ViewHelper\Url;
             $router = Console::isConsole() ? 'HttpRouter' : 'Router';
             $helper->setRouter($services->get($router));
@@ -162,11 +157,6 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
     private function createBasePathHelperFactory(ContainerInterface $services)
     {
         return function () use ($services) {
-            // zend-servicemanager v2: fetch parent locator
-            if (method_exists($services, 'getServiceLocator') && ! method_exists($services, 'configure')) {
-                $services = $services->getServiceLocator() ?: $services;
-            }
-
             $config = $services->has('config') ? $services->get('config') : [];
             $helper = new ViewHelper\BasePath;
 
@@ -204,11 +194,6 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
     private function createDoctypeHelperFactory(ContainerInterface $services)
     {
         return function () use ($services) {
-            // zend-servicemanager v2: fetch parent locator
-            if (method_exists($services, 'getServiceLocator') && ! method_exists($services, 'configure')) {
-                $services = $services->getServiceLocator() ?: $services;
-            }
-
             $config = $services->has('config') ? $services->get('config') : [];
             $config = isset($config['view_manager']) ? $config['view_manager'] : [];
             $helper = new ViewHelper\Doctype;

--- a/src/Service/ViewHelperManagerFactory.php
+++ b/src/Service/ViewHelperManagerFactory.php
@@ -138,7 +138,7 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
             $router = Console::isConsole() ? 'HttpRouter' : 'Router';
             $helper->setRouter($services->get($router));
 
-            $match = $services->get('application')
+            $match = $services->get('Application')
                 ->getMvcEvent()
                 ->getRouteMatch()
             ;

--- a/test/Service/ServiceListenerFactoryTest.php
+++ b/test/Service/ServiceListenerFactoryTest.php
@@ -10,18 +10,26 @@
 namespace ZendTest\Mvc\Service;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionClass;
 use ReflectionProperty;
 use Zend\Mvc\Service\ServiceListenerFactory;
+use Zend\ServiceManager\ServiceManager;
 
 class ServiceListenerFactoryTest extends TestCase
 {
     public function setUp()
     {
-        $sm = $this->sm = $this->getMockBuilder('Zend\ServiceManager\ServiceManager')
+        $sm = $this->sm = $this->getMockBuilder(ServiceManager::class)
                                ->setMethods(['get'])
                                ->getMock();
 
         $this->factory  = new ServiceListenerFactory();
+    }
+
+    private function isServiceManagerV3()
+    {
+        $r = new ReflectionClass(ServiceManager::class);
+        return $r->hasMethod('configure');
     }
 
     /**
@@ -190,5 +198,79 @@ class ServiceListenerFactoryTest extends TestCase
         $this->assertArrayHasKey('aliases', $config, 'Missing aliases from default service config');
         $this->assertArrayHasKey('console', $config['aliases'], 'Missing "console" alias from default service config');
         $this->assertArrayHasKey('Console', $config['aliases'], 'Missing "Console" alias from default service config');
+    }
+
+    public function testDefinesExpectedApplicationAliasesUnderV3()
+    {
+        if (! $this->isServiceManagerV3()) {
+            $this->markTestSkipped('Application aliases are only defined under zend-servicemanager v3');
+        }
+
+        $r = new ReflectionProperty($this->factory, 'defaultServiceConfig');
+        $r->setAccessible(true);
+        $config = $r->getValue($this->factory);
+
+        // @codingStandardsIgnoreStart
+        $this->assertArrayHasKey('aliases', $config, 'Missing aliases from default service config');
+        $this->assertArrayHasKey('application', $config['aliases'], 'Missing "application" alias from default service config');
+        // @codingStandardsIgnoreEnd
+    }
+
+    public function testDefinesExpectedConfigAliasesUnderV3()
+    {
+        if (! $this->isServiceManagerV3()) {
+            $this->markTestSkipped('Config aliases are only defined under zend-servicemanager v3');
+        }
+
+        $r = new ReflectionProperty($this->factory, 'defaultServiceConfig');
+        $r->setAccessible(true);
+        $config = $r->getValue($this->factory);
+
+        $this->assertArrayHasKey('aliases', $config, 'Missing aliases from default service config');
+        $this->assertArrayHasKey('Config', $config['aliases'], 'Missing "Config" alias from default service config');
+    }
+
+    public function testDefinesExpectedRequestAliasesUnderV3()
+    {
+        if (! $this->isServiceManagerV3()) {
+            $this->markTestSkipped('Request aliases are only defined under zend-servicemanager v3');
+        }
+
+        $r = new ReflectionProperty($this->factory, 'defaultServiceConfig');
+        $r->setAccessible(true);
+        $config = $r->getValue($this->factory);
+
+        $this->assertArrayHasKey('aliases', $config, 'Missing aliases from default service config');
+        $this->assertArrayHasKey('request', $config['aliases'], 'Missing "request" alias from default service config');
+    }
+
+    public function testDefinesExpectedResponseFactories()
+    {
+        if (! $this->isServiceManagerV3()) {
+            $this->markTestSkipped('Response aliases are only defined under zend-servicemanager v3');
+        }
+
+        $r = new ReflectionProperty($this->factory, 'defaultServiceConfig');
+        $r->setAccessible(true);
+        $config = $r->getValue($this->factory);
+
+        // @codingStandardsIgnoreStart
+        $this->assertArrayHasKey('aliases', $config, 'Missing aliases from default service config');
+        $this->assertArrayHasKey('response', $config['aliases'], 'Missing "response" alias from default service config');
+        // @codingStandardsIgnoreEnd
+    }
+
+    public function testDefinesExpectedRouterAliases()
+    {
+        if (! $this->isServiceManagerV3()) {
+            $this->markTestSkipped('Router aliases are only defined under zend-servicemanager v3');
+        }
+
+        $r = new ReflectionProperty($this->factory, 'defaultServiceConfig');
+        $r->setAccessible(true);
+        $config = $r->getValue($this->factory);
+
+        $this->assertArrayHasKey('aliases', $config, 'Missing aliases from default service config');
+        $this->assertArrayHasKey('router', $config['aliases'], 'Missing "router" alias from default service config');
     }
 }

--- a/test/Service/ViewHelperManagerFactoryTest.php
+++ b/test/Service/ViewHelperManagerFactoryTest.php
@@ -124,6 +124,7 @@ class ViewHelperManagerFactoryTest extends TestCase
         $this->services->setService('HttpRouter', $router);
         $this->services->setService('Router', $router);
         $this->services->setService('application', $application->reveal());
+        $this->services->setService('Application', $application->reveal());
         $this->services->setService('config', []);
 
         $manager = $this->factory->createService($this->services);

--- a/test/Service/ViewHelperManagerFactoryTest.php
+++ b/test/Service/ViewHelperManagerFactoryTest.php
@@ -123,7 +123,6 @@ class ViewHelperManagerFactoryTest extends TestCase
 
         $this->services->setService('HttpRouter', $router);
         $this->services->setService('Router', $router);
-        $this->services->setService('application', $application->reveal());
         $this->services->setService('Application', $application->reveal());
         $this->services->setService('config', []);
 


### PR DESCRIPTION
This patch builds on #80 and takes a different approach: conditionally declaring aliases when under zend-servicemanager v3.

This approach:
- solves issues of circular alias de-referencing
- ensures that retrieval using different casing combinations will retrieve the same instance (declaring multiple factory entries breaks this)
- keeps backwards compatibility (as common use case scenarios — specifically, fetching by Wordcase vs lowercase — continue to work)
