### PR TITLE
Ensure listener detachment works cross-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "zendframework/zend-version": "^2.5",
         "zendframework/zend-view": "^2.6.3",
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "phpunit/PHPUnit": "^4.5",
+        "sebastian/version": "^1.0.4"
     },
     "suggest": {
         "zendframework/zend-authentication": "Zend\\Authentication component for Identity plugin",

--- a/src/Controller/Plugin/Forward.php
+++ b/src/Controller/Plugin/Forward.php
@@ -184,8 +184,8 @@ class Forward extends AbstractPlugin
 
                     // zend-eventmanager v2 compatibility:
                     if ($currentCallback instanceof CallbackHandler) {
-                        $currentCallback = $currentCallback->getCallback();
-                        $priority        = $currentCallback->getMetadatum('priority');
+                        $currentCallback = $currentEvent->getCallback();
+                        $priority        = $currentEvent->getMetadatum('priority');
                     }
 
                     // If we have an array, grab the object


### PR DESCRIPTION
Check if a returned callback is a CallbackHandler, and, if so, pull the actual PHP callable from it before testing for the class. To ensure both BC and forwards compatibility, ensure that the priority is stored when detaching, so that re-attaching will continue to work.

In order to use `composer update --prefer-lowest` (which I did for testing against zend-eventmanager v2), I had to:
- update PHPUnit to `^4.5`, as that's the first version using prophecy, which we're using in tests now.
- add sebastian/version:^1.0.4, as that's the first version that fixes version autodiscovery, ensuring that the test runner knows we're on a version later than 2.5.

Tests for this are ridiculously hard to write; would love some review!
