### PR TITLE
Re-introduce 'ServiceManager' factory

### DIFF
--- a/src/Service/ServiceManagerConfig.php
+++ b/src/Service/ServiceManagerConfig.php
@@ -76,6 +76,10 @@ class ServiceManagerConfig extends Config
      */
     public function __construct(array $config = [])
     {
+        $this->config['factories']['ServiceManager'] = function ($container) {
+            return $container;
+        };
+
         $this->config['factories']['SharedEventManager'] = function () {
             return new SharedEventManager();
         };

--- a/test/Service/ServiceManagerConfigTest.php
+++ b/test/Service/ServiceManagerConfigTest.php
@@ -212,4 +212,17 @@ class ServiceManagerConfigTest extends TestCase
 
         $serviceManager->get('EventManagerAware');
     }
+
+    /**
+     * @group 101
+     */
+    public function testCreatesAFactoryForTheServiceManagerThatReturnsIt()
+    {
+        $serviceManager = new ServiceManager();
+        $config         = new ServiceManagerConfig();
+        $config->configureServiceManager($serviceManager);
+
+        $this->assertTrue($serviceManager->has('ServiceManager'), 'Missing ServiceManager service!');
+        $this->assertSame($serviceManager, $serviceManager->get('ServiceManager'));
+    }
 }


### PR DESCRIPTION
Returns provided container on invocation. Added to remove a BC break reported in zendframework/zend-servicemanager#101.
