### PR TITLE
Fix for Forward in zend-eventmanager v3

### DIFF
--- a/src/Controller/Plugin/Forward.php
+++ b/src/Controller/Plugin/Forward.php
@@ -184,6 +184,7 @@ class Forward extends AbstractPlugin
                     if (!is_array($currentPriorityEvents)) {
                         $currentPriorityEvents = array($currentPriorityEvents);
                     }
+                    
                     // v3
                     foreach ($currentPriorityEvents as $currentEvent) {
                         $currentCallback = $currentEvent;

--- a/src/Controller/Plugin/Forward.php
+++ b/src/Controller/Plugin/Forward.php
@@ -182,9 +182,8 @@ class Forward extends AbstractPlugin
                 foreach ($events as $priority => $currentPriorityEvents) {
                     // v2 fix
                     if (!is_array($currentPriorityEvents)) {
-                        $currentPriorityEvents = array($currentPriorityEvents);
+                        $currentPriorityEvents = [$currentPriorityEvents];
                     }
-                    
                     // v3
                     foreach ($currentPriorityEvents as $currentEvent) {
                         $currentCallback = $currentEvent;

--- a/src/Controller/Plugin/Forward.php
+++ b/src/Controller/Plugin/Forward.php
@@ -179,32 +179,39 @@ class Forward extends AbstractPlugin
             foreach ($eventArray as $eventName => $classArray) {
                 $results[$id][$eventName] = [];
                 $events = $this->getSharedListenersById($id, $eventName, $sharedEvents);
-                foreach ($events as $priority => $currentEvent) {
-                    $currentCallback = $currentEvent;
-
-                    // zend-eventmanager v2 compatibility:
-                    if ($currentCallback instanceof CallbackHandler) {
-                        $currentCallback = $currentEvent->getCallback();
-                        $priority        = $currentEvent->getMetadatum('priority');
+                foreach ($events as $priority => $currentPriorityEvents) {
+                    // v2 fix
+                    if (!is_array($currentPriorityEvents)) {
+                        $currentPriorityEvents = array($currentPriorityEvents);
                     }
+                    // v3
+                    foreach ($currentPriorityEvents as $currentEvent) {
+                        $currentCallback = $currentEvent;
 
-                    // If we have an array, grab the object
-                    if (is_array($currentCallback)) {
-                        $currentCallback = array_shift($currentCallback);
-                    }
+                        // zend-eventmanager v2 compatibility:
+                        if ($currentCallback instanceof CallbackHandler) {
+                            $currentCallback = $currentEvent->getCallback();
+                            $priority = $currentEvent->getMetadatum('priority');
+                        }
 
-                    // This routine is only valid for object callbacks
-                    if (!is_object($currentCallback)) {
-                        continue;
-                    }
+                        // If we have an array, grab the object
+                        if (is_array($currentCallback)) {
+                            $currentCallback = array_shift($currentCallback);
+                        }
 
-                    foreach ($classArray as $class) {
-                        if ($currentCallback instanceof $class) {
-                            // Pass $currentEvent; when using zend-eventmanager v2,
-                            // this is the CallbackHandler, while in v3 it's
-                            // the actual listener.
-                            $this->detachSharedListener($id, $currentEvent, $sharedEvents);
-                            $results[$id][$eventName][$priority] = $currentEvent;
+                        // This routine is only valid for object callbacks
+                        if (!is_object($currentCallback)) {
+                            continue;
+                        }
+
+                        foreach ($classArray as $class) {
+                            if ($currentCallback instanceof $class) {
+                                // Pass $currentEvent; when using zend-eventmanager v2,
+                                // this is the CallbackHandler, while in v3 it's
+                                // the actual listener.
+                                $this->detachSharedListener($id, $currentEvent, $sharedEvents);
+                                $results[$id][$eventName][$priority] = $currentEvent;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Actually,

EventManager returns an ARRAY on `$sharedEvents->getListeners` and the way it was implemented the `listenersToDetach` it wasn't working. 
I don't know if in V2 it is the same thing, so, this pull request FIX this method and a problem from rendering the View two times.

Like this old bug: http://zend-framework-community.634137.n4.nabble.com/Double-rendering-with-forward-plugin-td4656067i20.html

Someone can check if it works on `zend-eventmanager` v2?

Thanks,

Rodrigo
