### PR TITLE
Fix issue with plugin manager detection in ServiceLocatorAware initializer

### DIFF
--- a/src/Service/ServiceManagerConfig.php
+++ b/src/Service/ServiceManagerConfig.php
@@ -111,9 +111,11 @@ class ServiceManagerConfig extends Config
             },
             'ServiceManagerAwareInitializer' => function ($first, $second) {
                 if ($first instanceof ContainerInterface) {
+                    // zend-servicemanager v3
                     $container = $first;
                     $instance = $second;
                 } else {
+                    // zend-servicemanager v2
                     $container = $second;
                     $instance = $first;
                 }
@@ -129,10 +131,16 @@ class ServiceManagerConfig extends Config
                 }
             },
             'ServiceLocatorAwareInitializer' => function ($first, $second) {
-                if ($first instanceof ContainerInterface) {
+                if ($first instanceof AbstractPluginManager) {
+                    // Edge case under zend-servicemanager v2
+                    $container = $second;
+                    $instance = $first;
+                } elseif ($first instanceof ContainerInterface) {
+                    // zend-servicemanager v3
                     $container = $first;
                     $instance = $second;
                 } else {
+                    // zend-servicemanager v2
                     $container = $second;
                     $instance = $first;
                 }


### PR DESCRIPTION
As reported in zendframework/zend-servicemanager#109, the "ServiceLocatorAware" initializer in zend-mvc breaks under the latest zend-servicemanager v2 versions due to mis-detection of the service container. Because both the SM instance itself and plugin managers implement `ContainerInterface`, the conditional used to detect a v3 variant of zend-servicemanager emits a false positive, as it falsely identifies the plugin manager as the service container.

This patch adds an additional conditional, checking against specifically `AbstractPluginManager`, so that it can properly identify which argument is the container, and which is the instance to initialize.

Fixes zendframework/zend-servicemanager#109
