### PR TITLE
Do not throw deprecated notice if serviceLocator is set

### DIFF
--- a/src/Service/ServiceManagerConfig.php
+++ b/src/Service/ServiceManagerConfig.php
@@ -150,6 +150,7 @@ class ServiceManagerConfig extends Config
                 // implementations; they're dealt with later.
                 if ($instance instanceof ServiceLocatorAwareInterface
                     && ! $instance instanceof AbstractPluginManager
+                    && ! $instance->getServiceLocator()
                 ) {
                     trigger_error(sprintf(
                         'ServiceLocatorAwareInterface is deprecated and will be removed in version 3.0, along '


### PR DESCRIPTION
I am not sure this is desired behavior, but seems strange. Noticed this while reviewing zfcUser module that removing `ServiceManagerAwareInterface` would be BC break. See this comment https://github.com/ZF-Commons/ZfcUser/pull/634#discussion-diff-59324273

For example for AbstractPluginManager you added check if service locator is set then do not throw deprecated error, but for modules like zfcUser there is no way to make it BC way.

@weierophinney maybe I am missing something? 
