### PR TITLE
Removed lowercase console alias from default service config

### DIFF
--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -41,9 +41,7 @@ class ServiceListenerFactory implements FactoryInterface
      */
     protected $defaultServiceConfig = [
         'aliases' => [
-            'configuration'                              => 'config',
             'Configuration'                              => 'config',
-            'console'                                    => 'ConsoleAdapter',
             'Console'                                    => 'ConsoleAdapter',
             'ConsoleDefaultRenderingStrategy'            => View\Console\DefaultRenderingStrategy::class,
             'ControllerLoader'                           => 'ControllerManager',

--- a/test/Service/ServiceListenerFactoryTest.php
+++ b/test/Service/ServiceListenerFactoryTest.php
@@ -196,8 +196,63 @@ class ServiceListenerFactoryTest extends TestCase
         $config = $r->getValue($this->factory);
 
         $this->assertArrayHasKey('aliases', $config, 'Missing aliases from default service config');
-        $this->assertArrayHasKey('console', $config['aliases'], 'Missing "console" alias from default service config');
         $this->assertArrayHasKey('Console', $config['aliases'], 'Missing "Console" alias from default service config');
+    }
+
+    public function testExpectedAliasesExistWithinDefaultServiceConfiguration()
+    {
+        $r = new ReflectionProperty($this->factory, 'defaultServiceConfig');
+        $r->setAccessible(true);
+        $config = $r->getValue($this->factory);
+
+        $this->assertArrayHasKey('aliases', $config, 'Missing aliases from default service config');
+    }
+
+    /**
+     * @dataProvider expectedAliasesDataProvider
+     * @param string $alias The key given for an alias within the default service configuration
+     */
+    public function testDefinedExpectedAliases($alias)
+    {
+        $r = new ReflectionProperty($this->factory, 'defaultServiceConfig');
+        $r->setAccessible(true);
+        $config = $r->getValue($this->factory);
+
+        $this->assertArrayHasKey(
+            $alias,
+            $config['aliases'],
+            sprintf('Missing %s alias from default service config', $alias)
+        );
+    }
+
+    public function expectedAliasesDataProvider()
+    {
+        return array(
+            'Configuration' => array('Configuration'),
+            'Console' => array('Console'),
+            'ConsoleDefaultRenderingStrategy' => array('ConsoleDefaultRenderingStrategy'),
+            'ControllerLoader' => array('ControllerLoader'),
+            'Di' => array('Di'),
+            'HttpDefaultRenderingStrategy' => array('HttpDefaultRenderingStrategy'),
+            'MiddlewareListener' => array('MiddlewareListener'),
+            'RouteListener' => array('RouteListener'),
+            'SendResponseListener' => array('SendResponseListener'),
+            'View' => array('View'),
+            'ViewFeedRenderer' => array('ViewFeedRenderer'),
+            'ViewJsonRenderer' => array('ViewJsonRenderer'),
+            'ViewPhpRendererStrategy' => array('ViewPhpRendererStrategy'),
+            'ViewPhpRenderer' => array('ViewPhpRenderer'),
+            'ViewRenderer' => array('ViewRenderer'),
+            'Zend\Di\LocatorInterface' => array('Zend\Di\LocatorInterface'),
+            'Zend\Form\Annotation\FormAnnotationBuilder' => array('Zend\Form\Annotation\FormAnnotationBuilder'),
+            'Zend\Mvc\Controller\PluginManager' => array('Zend\Mvc\Controller\PluginManager'),
+            'Zend\Mvc\View\Http\InjectTemplateListener' => array('Zend\Mvc\View\Http\InjectTemplateListener'),
+            'Zend\View\Renderer\RendererInterface' => array('Zend\View\Renderer\RendererInterface'),
+            'Zend\View\Resolver\TemplateMapResolver' => array('Zend\View\Resolver\TemplateMapResolver'),
+            'Zend\View\Resolver\TemplatePathStack' => array('Zend\View\Resolver\TemplatePathStack'),
+            'Zend\View\Resolver\AggregateResolver' => array('Zend\View\Resolver\AggregateResolver'),
+            'Zend\View\Resolver\ResolverInterface' => array('Zend\View\Resolver\ResolverInterface'),
+        );
     }
 
     public function testDefinesExpectedApplicationAliasesUnderV3()


### PR DESCRIPTION
An alias was added in the `ServiceListenerFactory` to add the lowercase
aliases for `console` and `config`. This caused a
`Zend\ServiceManager\Exception\InvalidServiceNameException` exception to
be throw within the Zend\ServiceManager package when using the default
configuration prior to v3.x.

Within Zend\ServiceManager v3.x, the service manager has become case
sensitive, meaning that this issue would be resolved.

However, as v2.x normalises the aliases, it classifies `console` and
`Console` as a duplicate key, and throws the aforementioned exception.

This is a fix is only required as of v2.x of zend-mvc

Added data provider tests for expected aliases for default config
