### PR TITLE
[BC break] Remove old InjectTemplateListener behavior

### DIFF
--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -105,6 +105,18 @@ class InjectTemplateListenerTest extends TestCase
         $this->assertEquals('custom', $model->getTemplate());
     }
 
+    public function testMapsSubNamespaceToSubDirectory()
+    {
+        $myViewModel  = new ViewModel();
+        $myController = new \ZendTest\Mvc\Controller\TestAsset\SampleController();
+        $this->event->setTarget($myController);
+        $this->event->setResult($myViewModel);
+
+        $this->listener->injectTemplate($this->event);
+
+        $this->assertEquals('zend-test/mvc/test-asset/sample', $myViewModel->getTemplate());
+    }
+
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromRouteMatch()
     {
         $this->routeMatch->setParam(ModuleRouteListener::MODULE_NAMESPACE, 'Aj\Controller\SweetAppleAcres\Reports');
@@ -134,7 +146,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($model);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('aj/sweet-apple-acres/reports/cider-sales/pinkie-pie-revenue', $model->getTemplate());
+        $this->assertEquals('aj/sweet-apple-acres/reports/sub/cider-sales/pinkie-pie-revenue', $model->getTemplate());
     }
 
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTarget()
@@ -152,7 +164,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($myViewModel);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('zend-test/controller/test-asset/sample/test', $myViewModel->getTemplate());
+        $this->assertEquals('zend-test/mvc/test-asset/sample/test', $myViewModel->getTemplate());
     }
 
     public function testMapsSubNamespaceToSubDirectoryWithControllerFromEventTargetShouldMatchControllerFromRouteParam()
@@ -199,19 +211,6 @@ class InjectTemplateListenerTest extends TestCase
         $this->listener->injectTemplate($this->event);
 
         $this->assertEquals('zend-test/mvc/test-asset/sample', $myViewModel->getTemplate());
-    }
-
-    public function testControllerNotMatchedByMapIsNotAffected()
-    {
-        $this->routeMatch->setParam('action', 'test');
-        $myViewModel  = new ViewModel();
-        $myController = new \ZendTest\Mvc\Controller\TestAsset\SampleController();
-
-        $this->event->setTarget($myController);
-        $this->event->setResult($myViewModel);
-        $this->listener->injectTemplate($this->event);
-
-        $this->assertEquals('zend-test/sample/test', $myViewModel->getTemplate());
     }
 
     public function testFullControllerNameMatchIsMapped()
@@ -339,6 +338,6 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($myViewModel);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('some/sample', $myViewModel->getTemplate());
+        $this->assertEquals('some/other/service/namespace/sample', $myViewModel->getTemplate());
     }
 }


### PR DESCRIPTION
Removed old pseudomodule template name resolution which ignored subnamespaces and used `__NAMESPACE__` variable in convoluted and non-intuitive ways. 
Whitelisted classname based template name resolution introduced in `^2.3.0` is now default
Template resolution follows these rules:
1. strip `\Controller\` namespace if present
2. strip trailing `Controller` in classname, unless classname is exactly `Controller`
3. inflect CamelCase to dash
4. replace namespace separator with slash

See https://github.com/zendframework/zendframework/pull/5670

This breaks backwards compatibility in some cases, check couple changed tests.

Affected modules can achieve compatibility with v2 and v3 simultaneously by adding whitelist entry to template map and moving templates or by mapping namespace to old location.

Needs documentation. If anyone is willing to write it for me I definitely won't object to that  
