### PR TITLE
consistent names for exception (v3)

### DIFF
--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -60,10 +60,10 @@ class MiddlewareListener extends AbstractListenerAggregate
         $caughtException = null;
         try {
             $return = $middleware(Psr7Request::fromZend($request), Psr7Response::fromZend($response));
-        } catch (\Throwable $exception) {
-            $caughtException = $exception;
-        } catch (\Exception $exception) {  // @TODO clean up once PHP 7 requirement is enforced
-            $caughtException = $exception;
+        } catch (\Throwable $ex) {
+            $caughtException = $ex;
+        } catch (\Exception $ex) {  // @TODO clean up once PHP 7 requirement is enforced
+            $caughtException = $ex;
         }
 
         if ($caughtException !== null) {
@@ -71,7 +71,7 @@ class MiddlewareListener extends AbstractListenerAggregate
             $event->setError($application::ERROR_EXCEPTION);
             $event->setController($middlewareName);
             $event->setControllerClass(get_class($middleware));
-            $event->setParam('exception', $exception);
+            $event->setParam('exception', $caughtException);
 
             $events  = $application->getEventManager();
             $results = $events->triggerEvent($event);

--- a/src/View/Http/DefaultRenderingStrategy.php
+++ b/src/View/Http/DefaultRenderingStrategy.php
@@ -111,14 +111,14 @@ class DefaultRenderingStrategy extends AbstractListenerAggregate
 
         if ($caughtException !== null) {
             if ($e->getName() === MvcEvent::EVENT_RENDER_ERROR) {
-                throw $ex;
+                throw $caughtException;
             }
 
             $application = $e->getApplication();
             $events      = $application->getEventManager();
 
             $e->setError(Application::ERROR_EXCEPTION);
-            $e->setParam('exception', $ex);
+            $e->setParam('exception', $caughtException);
             $e->setName(MvcEvent::EVENT_RENDER_ERROR);
             $events->triggerEvent($e);
         }


### PR DESCRIPTION
small fix - renamed variables (for consistency with other occurrences) and to avoid notice in IDE "variable might have not been defined"
