### PR TITLE
ControllerLoaderFactory fix + deprecated (v2)

### DIFF
--- a/src/Service/ControllerLoaderFactory.php
+++ b/src/Service/ControllerLoaderFactory.php
@@ -13,6 +13,10 @@ use Zend\Mvc\Controller\ControllerManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
+/**
+ * @deprecated please use the {@see \Zend\Mvc\Service\ControllerManagerFactory} factory instead:
+ *             this class will be removed in release 3.0
+ */
 class ControllerLoaderFactory implements FactoryInterface
 {
     /**
@@ -33,6 +37,12 @@ class ControllerLoaderFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
+        trigger_error(sprintf(
+            '%s is deprecated; please use %s instead',
+            __CLASS__,
+            ControllerManagerFactory::class
+        ), E_USER_DEPRECATED);
+
         $controllerLoader = new ControllerManager($serviceLocator);
         $controllerLoader->addPeeringServiceManager($serviceLocator);
 

--- a/src/Service/ControllerLoaderFactory.php
+++ b/src/Service/ControllerLoaderFactory.php
@@ -33,8 +33,7 @@ class ControllerLoaderFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $controllerLoader = new ControllerManager();
-        $controllerLoader->setServiceLocator($serviceLocator);
+        $controllerLoader = new ControllerManager($serviceLocator);
         $controllerLoader->addPeeringServiceManager($serviceLocator);
 
         $config = $serviceLocator->get('Config');


### PR DESCRIPTION
Fix for creation `ControllerManager` in `ControllerLoaderFactory` and the factory marked as deprecated. It is already removed in v3 and `ControllerManagerFactory` should be used instead.
