### PR TITLE
call with Throwable, but type-hint wants Exception

### DIFF
--- a/src/DispatchListener.php
+++ b/src/DispatchListener.php
@@ -235,14 +235,14 @@ class DispatchListener extends AbstractListenerAggregate
      * @param  string $controllerName
      * @param  MvcEvent $event
      * @param  Application $application
-     * @param  \Exception $exception
+     * @param  \Exception|\Throwable $exception
      * @return mixed
      */
     protected function marshalBadControllerEvent(
         $controllerName,
         MvcEvent $event,
         Application $application,
-        \Exception $exception
+        $exception // @TODO clean up once PHP 7 requirement is enforced
     ) {
         $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
         $event->setError($application::ERROR_EXCEPTION);


### PR DESCRIPTION
hi,

i get the same problem like https://github.com/zendframework/zend-mvc/issues/146 with release-3.0.0.

in `Zend\Mvc\DispatchListener` https://github.com/zendframework/zend-mvc/blob/master/src/DispatchListener.php#L103 is the method call with `Throwable` but the type-hint want an `Exception` class https://github.com/zendframework/zend-mvc/blob/release-3.0.0/src/DispatchListener.php#L219

Im not sure if the fix should be only in the release-3.x.x. or also in release-2.7.x.

PHP-Version 7.0.7
