### PR TITLE
Update zend-mvc v2 to use zend-servicemanager-di

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: php
 
 branches:
   except:
-    - /^release-.*$/
+    - /^release-\d+\.\d+\.\d+.*$/
     - /^ghgfk-.*$/
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "php": "^5.5 || ^7.0",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-servicemanager-di": "^1.0.1",
         "zendframework/zend-hydrator": "^1.1 || ^2.1",
         "zendframework/zend-form": "^2.7",
         "zendframework/zend-stdlib": "^2.7.5 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1ead671a9764c969d80511a14f87dd0b",
-    "content-hash": "473b7929155540bda1953575e48520dd",
+    "hash": "5f138a5ebde4fab2be821687b60a367d",
+    "content-hash": "b43c5894b1a9b18d8f31f42864293f06",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -82,6 +82,106 @@
                 "response"
             ],
             "time": "2015-05-04 20:22:00"
+        },
+        {
+            "name": "zendframework/zend-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-code.git",
+                "reference": "09405eb04b7199733219cbf1f0803883a7bab842"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/09405eb04b7199733219cbf1f0803883a7bab842",
+                "reference": "09405eb04b7199733219cbf1f0803883a7bab842",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^4.8.21",
+                "squizlabs/php_codesniffer": "^2.5",
+                "zendframework/zend-stdlib": "~2.7"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "zendframework/zend-stdlib": "Zend\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides facilities to generate arbitrary code using an object oriented interface",
+            "homepage": "https://github.com/zendframework/zend-code",
+            "keywords": [
+                "code",
+                "zf2"
+            ],
+            "time": "2016-01-26 17:57:25"
+        },
+        {
+            "name": "zendframework/zend-di",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-di.git",
+                "reference": "c271c25c3e0ce194cbfbf05c9e56444d9f98456e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-di/zipball/c271c25c3e0ce194cbfbf05c9e56444d9f98456e",
+                "reference": "c271c25c3e0ce194cbfbf05c9e56444d9f98456e",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-code": "^2.6 || ^3.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev",
+                    "dev-develop": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Di\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-di",
+            "keywords": [
+                "di",
+                "zf2"
+            ],
+            "time": "2016-02-23 20:38:54"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -661,6 +761,57 @@
                 "zf"
             ],
             "time": "2016-02-02 14:13:42"
+        },
+        {
+            "name": "zendframework/zend-servicemanager-di",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-servicemanager-di.git",
+                "reference": "d894ab9e517ea711772480acb0ecb88deee14672"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager-di/zipball/d894ab9e517ea711772480acb0ecb88deee14672",
+                "reference": "d894ab9e517ea711772480acb0ecb88deee14672",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-di": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5",
+                "squizlabs/php_codesniffer": "^2.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev",
+                    "dev-develop": "1.1-dev"
+                },
+                "zf": {
+                    "component": "Zend\\ServiceManager\\Di",
+                    "config-provider": "Zend\\ServiceManager\\Di\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\ServiceManager\\Di\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-servicemanager-di",
+            "keywords": [
+                "di",
+                "zf2"
+            ],
+            "time": "2016-06-09 21:23:32"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -2369,59 +2520,6 @@
             "time": "2016-02-12 16:26:56"
         },
         {
-            "name": "zendframework/zend-code",
-            "version": "3.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "09405eb04b7199733219cbf1f0803883a7bab842"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/09405eb04b7199733219cbf1f0803883a7bab842",
-                "reference": "09405eb04b7199733219cbf1f0803883a7bab842",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "~1.0",
-                "ext-phar": "*",
-                "phpunit/phpunit": "^4.8.21",
-                "squizlabs/php_codesniffer": "^2.5",
-                "zendframework/zend-stdlib": "~2.7"
-            },
-            "suggest": {
-                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
-                "zendframework/zend-stdlib": "Zend\\Stdlib component"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Code\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides facilities to generate arbitrary code using an object oriented interface",
-            "homepage": "https://github.com/zendframework/zend-code",
-            "keywords": [
-                "code",
-                "zf2"
-            ],
-            "time": "2016-01-26 17:57:25"
-        },
-        {
             "name": "zendframework/zend-console",
             "version": "2.6.0",
             "source": {
@@ -2472,53 +2570,6 @@
                 "zf2"
             ],
             "time": "2016-02-09 17:15:12"
-        },
-        {
-            "name": "zendframework/zend-di",
-            "version": "2.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-di.git",
-                "reference": "c271c25c3e0ce194cbfbf05c9e56444d9f98456e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-di/zipball/c271c25c3e0ce194cbfbf05c9e56444d9f98456e",
-                "reference": "c271c25c3e0ce194cbfbf05c9e56444d9f98456e",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/container-interop": "^1.1",
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-code": "^2.6 || ^3.0",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
-            },
-            "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Di\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "homepage": "https://github.com/zendframework/zend-di",
-            "keywords": [
-                "di",
-                "zf2"
-            ],
-            "time": "2016-02-23 20:38:54"
         },
         {
             "name": "zendframework/zend-i18n",

--- a/src/Service/DiAbstractServiceFactoryFactory.php
+++ b/src/Service/DiAbstractServiceFactoryFactory.php
@@ -9,43 +9,17 @@
 
 namespace Zend\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Di\DiAbstractServiceFactory;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Di\DiAbstractServiceFactoryFactory as OriginalFactory;
 
-class DiAbstractServiceFactoryFactory implements FactoryInterface
+/**
+ * Since 2.7.9, this class now extends the version defined in zend-servicemanager-di,
+ * ensuring backwards compatibility with zend-servicemanger v2 and forwards
+ * compatibility with zend-servicemanager v3.
+ *
+ * @deprecated Since 2.7.9. The factory is now defined in zend-servicemanager-di,
+ *     and removed in 3.0.0. Use Zend\ServiceManager\Di\DiAbstractServiceFactoryFactory
+ *     from zend-servicemanager-di instead if you rely on this feature.
+ */
+class DiAbstractServiceFactoryFactory extends OriginalFactory
 {
-    /**
-     * Class responsible for instantiating a DiAbstractServiceFactory
-     *
-     * @param ContainerInterface $container
-     * @param string $name
-     * @param null|array $options
-     * @return DiAbstractServiceFactory
-     */
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
-    {
-        $factory = new DiAbstractServiceFactory($container->get('Di'), DiAbstractServiceFactory::USE_SL_BEFORE_DI);
-
-        if ($serviceLocator instanceof ServiceManager) {
-            $serviceLocator->addAbstractFactory($factory, false);
-        }
-
-        return $factory;
-    }
-
-    /**
-     * Create and return DiAbstractServiceFactory instance
-     *
-     * For use with zend-servicemanager v2; proxies to __invoke().
-     *
-     * @param ServiceLocatorInterface $container
-     * @return DiAbstractServiceFactory
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, DiAbstractServiceFactory::class);
-    }
 }

--- a/src/Service/DiFactory.php
+++ b/src/Service/DiFactory.php
@@ -9,52 +9,17 @@
 
 namespace Zend\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
-use Zend\Di\Config;
-use Zend\Di\Di;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\Di\DiFactory as OriginalFactory;
 
-class DiFactory implements FactoryInterface
+/**
+ * Since 2.7.9, this class now extends the version defined in zend-servicemanager-di,
+ * ensuring backwards compatibility with zend-servicemanger v2 and forwards
+ * compatibility with zend-servicemanager v3.
+ *
+ * @deprecated Since 2.7.9. The factory is now defined in zend-servicemanager-di,
+ *     and removed in 3.0.0. Use Zend\ServiceManager\Di\DiFactory from
+ *     zend-servicemanager-di instead if you rely on this feature.
+ */
+class DiFactory extends OriginalFactory
 {
-    /**
-     * Create and return abstract factory seeded by dependency injector
-     *
-     * Creates and returns an abstract factory seeded by the dependency
-     * injector. If the "di" key of the configuration service is set, that
-     * sub-array is passed to a DiConfig object and used to configure
-     * the DI instance. The DI instance is then used to seed the
-     * DiAbstractServiceFactory, which is then registered with the service
-     * manager.
-     *
-     * @param ContainerInterface $container
-     * @param string $name
-     * @param null|array $options
-     * @return Di
-     */
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
-    {
-        $di     = new Di();
-        $config = $container->get('config');
-
-        if (isset($config['di'])) {
-            $config = new Config($config['di']);
-            $config->configure($di);
-        }
-
-        return $di;
-    }
-
-    /**
-     * Create and return Di instance
-     *
-     * For use with zend-servicemanager v2; proxies to __invoke().
-     *
-     * @param ServiceLocatorInterface $container
-     * @return Di
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, Di::class);
-    }
 }

--- a/src/Service/DiServiceInitializerFactory.php
+++ b/src/Service/DiServiceInitializerFactory.php
@@ -9,36 +9,17 @@
 
 namespace Zend\Mvc\Service;
 
-use Container\Interop\ContainerInterface;
-use Zend\ServiceManager\Di\DiServiceInitializer;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\Di\DiServiceInitializerFactory as OriginalFactory;
 
-class DiServiceInitializerFactory implements FactoryInterface
+/**
+ * Since 2.7.9, this class now extends the version defined in zend-servicemanager-di,
+ * ensuring backwards compatibility with zend-servicemanger v2 and forwards
+ * compatibility with zend-servicemanager v3.
+ *
+ * @deprecated Since 2.7.9. The factory is now defined in zend-servicemanager-di,
+ *     and removed in 3.0.0. Use Zend\ServiceManager\Di\DiServiceInitializerFactory
+ *     from zend-servicemanager-di instead if you rely on this feature.
+ */
+class DiServiceInitializerFactory extends OriginalFactory
 {
-    /**
-     * Class responsible for instantiating a DiServiceInitializer
-     *
-     * @param ContainerInterface $container
-     * @param string $name
-     * @param null|array $options
-     * @return DiServiceInitializer
-     */
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
-    {
-        return new DiServiceInitializer($container->get('Di'), $container);
-    }
-
-    /**
-     * Create and return DiServiceInitializer instance
-     *
-     * For use with zend-servicemanager v2; proxies to __invoke().
-     *
-     * @param ServiceLocatorInterface $container
-     * @return DiServiceInitializer
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, DiServiceInitializer::class);
-    }
 }

--- a/src/Service/DiStrictAbstractServiceFactory.php
+++ b/src/Service/DiStrictAbstractServiceFactory.php
@@ -9,154 +9,17 @@
 
 namespace Zend\Mvc\Service;
 
-use Interop\Container\ContainerInterface;
-use Zend\Di\Di;
-use Zend\Di\Exception\ClassNotFoundException;
-use Zend\Mvc\Exception\DomainException;
-use Zend\ServiceManager\AbstractFactoryInterface;
-use Zend\ServiceManager\AbstractPluginManager;
-use Zend\ServiceManager\Exception;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\Di\DiStrictAbstractServiceFactory as OriginalFactory;
 
-class DiStrictAbstractServiceFactory extends Di implements AbstractFactoryInterface
+/**
+ * Since 2.7.9, this class now extends the version defined in zend-servicemanager-di,
+ * ensuring backwards compatibility with zend-servicemanger v2 and forwards
+ * compatibility with zend-servicemanager v3.
+ *
+ * @deprecated Since 2.7.9. The factory is now defined in zend-servicemanager-di,
+ *     and removed in 3.0.0. Use Zend\ServiceManager\Di\DiStrictAbstractServiceFactory
+ *     from zend-servicemanager-di instead if you rely on this feature.
+ */
+class DiStrictAbstractServiceFactory extends OriginalFactory
 {
-    /**@#+
-     * constants
-     */
-    const USE_SL_BEFORE_DI = 'before';
-    const USE_SL_AFTER_DI  = 'after';
-    const USE_SL_NONE      = 'none';
-    /**@#-*/
-
-    /**
-     * @var Di
-     */
-    protected $di = null;
-
-    /**
-     * @var string
-     */
-    protected $useServiceLocator = self::USE_SL_AFTER_DI;
-
-    /**
-     * @var ContainerInterface
-     */
-    protected $serviceLocator = null;
-
-    /**
-     * @var array an array of whitelisted service names (keys are the service names)
-     */
-    protected $allowedServiceNames = [];
-
-    /**
-     * @param Di $di
-     * @param string $useServiceLocator
-     */
-    public function __construct(Di $di, $useServiceLocator = self::USE_SL_NONE)
-    {
-        $this->useServiceLocator = $useServiceLocator;
-        // since we are using this in a proxy-fashion, localize state
-        $this->di              = $di;
-        $this->definitions     = $this->di->definitions;
-        $this->instanceManager = $this->di->instanceManager;
-    }
-
-    /**
-     * @param array $allowedServiceNames
-     */
-    public function setAllowedServiceNames(array $allowedServiceNames)
-    {
-        $this->allowedServiceNames = array_flip(array_values($allowedServiceNames));
-    }
-
-    /**
-     * @return array
-     */
-    public function getAllowedServiceNames()
-    {
-        return array_keys($this->allowedServiceNames);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * Allows creation of services only when in a whitelist
-     */
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
-    {
-        if (!isset($this->allowedServiceNames[$name])) {
-            throw new Exception\InvalidServiceException('Service "' . $name . '" is not whitelisted');
-        }
-
-        if ($container instanceof AbstractPluginManager) {
-            $this->serviceLocator = $container->getServiceLocator();
-        } else {
-            $this->serviceLocator = $container;
-        }
-
-        return parent::get($name);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * For use with zend-servicemanager v2; proxies to __invoke().
-     */
-    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $serviceName, $requestedName)
-    {
-        return $this($serviceLocator, $requestedName);
-    }
-
-    /**
-     * Overrides Zend\Di to allow the given serviceLocator's services to be reused by Di itself
-     *
-     * {@inheritDoc}
-     *
-     * @throws Exception\InvalidServiceNameException
-     */
-    public function get($name, array $params = [])
-    {
-        if (null === $this->serviceLocator) {
-            throw new DomainException('No ServiceLocator defined, use `createServiceWithName` instead of `get`');
-        }
-
-        if (self::USE_SL_BEFORE_DI === $this->useServiceLocator && $this->serviceLocator->has($name)) {
-            return $this->serviceLocator->get($name);
-        }
-
-        try {
-            return parent::get($name, $params);
-        } catch (ClassNotFoundException $e) {
-            if (self::USE_SL_AFTER_DI === $this->useServiceLocator && $this->serviceLocator->has($name)) {
-                return $this->serviceLocator->get($name);
-            }
-
-            throw new Exception\ServiceNotFoundException(
-                sprintf('Service %s was not found in this DI instance', $name),
-                null,
-                $e
-            );
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * Allows creation of services only when in a whitelist.
-     */
-    public function canCreate(ContainerInterface $container, $requestedName)
-    {
-        // won't check if the service exists, we are trusting the user's whitelist
-        return isset($this->allowedServiceNames[$requestedName]);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * For use with zend-servicemanager v2; proxies to canCreate().
-     */
-    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
-    {
-        return $this->canCreate($serviceLocator, $requestedName);
-    }
 }

--- a/src/Service/DiStrictAbstractServiceFactoryFactory.php
+++ b/src/Service/DiStrictAbstractServiceFactoryFactory.php
@@ -13,6 +13,11 @@ use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
+/**
+ * @deprecated Since 2.7.9. The factory is now defined in zend-servicemanager-di,
+ *     and removed in 3.0.0. Use Zend\ServiceManager\Di\DiStrictAbstractServiceFactoryFactory
+ *     from zend-servicemanager-di instead if you rely on this feature.
+ */
 class DiStrictAbstractServiceFactoryFactory implements FactoryInterface
 {
     /**


### PR DESCRIPTION
zend-servicemanager-di contains tests and code to ensure it works against both v2 and v3 versions of zend-servicemanager, unlike the code currently in zend-mvc. Updating to use it is backwards compatible, assuming the following:
- zend-servicemanager-di is tested against both v2 and v3 of zend-servicemanager, demonstrating that the various classes it contains that overlap with zend-servicemanager v2 pose no conflicts.
- each of DiAbstractServiceFactoryFactory, DiFactory, DiServiceInitializerFactory, and DiStrictAbstractServiceFactory from zend-mvc v2 return artifacts from the `Zend\ServiceManager\Di` namespace, allowing them to simply extend the relevant factories that exist in zend-servicemanager-di.
- DiStrictAbstractServiceFactoryFactory can be left intact, ensuring it returns the `Zend\Mvc\Service\DiStrictAbstractServiceFactory` instance, and thus preserving the inheritance tree.

All of the DI-related factories in zend-mvc are now marked deprecated as well, with annotations detailing how to upgrade code to work with zend-servicemanager-di to make it forwards-compatible.

This pull request supercedes #149 (the tests of which were incorporated directly in zend-servicemanager-di).
