### PR TITLE
InjectTemplateListener - returnn api proper view 

### DIFF
--- a/src/Controller/Plugin/AcceptableViewModelSelector.php
+++ b/src/Controller/Plugin/AcceptableViewModelSelector.php
@@ -209,6 +209,9 @@ class AcceptableViewModelSelector extends AbstractPlugin
     protected function injectViewModelName($modelAcceptString, $modelName)
     {
         $modelName = str_replace('\\', '|', $modelName);
+        $modelAcceptString = (is_array($modelAcceptString ))
+            ? $modelAcceptString[key($modelAcceptString)]
+            : $modelAcceptString;
         return $modelAcceptString . '; ' . self::INJECT_VIEWMODEL_NAME . '="' . $modelName . '", ';
     }
 

--- a/src/Controller/Plugin/AcceptableViewModelSelector.php
+++ b/src/Controller/Plugin/AcceptableViewModelSelector.php
@@ -209,7 +209,7 @@ class AcceptableViewModelSelector extends AbstractPlugin
     protected function injectViewModelName($modelAcceptString, $modelName)
     {
         $modelName = str_replace('\\', '|', $modelName);
-        $modelAcceptString = (is_array($modelAcceptString ))
+        $modelAcceptString = (is_array($modelAcceptString))
             ? $modelAcceptString[key($modelAcceptString)]
             : $modelAcceptString;
         return $modelAcceptString . '; ' . self::INJECT_VIEWMODEL_NAME . '="' . $modelName . '", ';

--- a/src/View/Http/InjectTemplateListener.php
+++ b/src/View/Http/InjectTemplateListener.php
@@ -61,7 +61,7 @@ class InjectTemplateListener extends AbstractListenerAggregate
         }
 
         $routeMatch = $e->getRouteMatch();
-        if($preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false)){
+        if ($preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false)) {
             $this->setPreferRouteMatchController($preferRouteMatchController);
         }
 

--- a/src/View/Http/InjectTemplateListener.php
+++ b/src/View/Http/InjectTemplateListener.php
@@ -61,6 +61,9 @@ class InjectTemplateListener extends AbstractListenerAggregate
         }
 
         $routeMatch = $e->getRouteMatch();
+        $preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false);
+        $this->setPreferRouteMatchController($preferRouteMatchController);
+
         $controller = $e->getTarget();
         if (is_object($controller)) {
             $controller = get_class($controller);

--- a/src/View/Http/InjectTemplateListener.php
+++ b/src/View/Http/InjectTemplateListener.php
@@ -61,8 +61,9 @@ class InjectTemplateListener extends AbstractListenerAggregate
         }
 
         $routeMatch = $e->getRouteMatch();
-        $preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false);
-        $this->setPreferRouteMatchController($preferRouteMatchController);
+        if($preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false)){
+            $this->setPreferRouteMatchController($preferRouteMatchController);
+        }
 
         $controller = $e->getTarget();
         if (is_object($controller)) {

--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -340,4 +340,28 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->assertEquals('some/other/service/namespace/sample', $myViewModel->getTemplate());
     }
+
+    public function testPrefersRouteMatchControllerWithRouteMatchAndControllerMap()
+    {
+        $this->assertFalse($this->listener->isPreferRouteMatchController());
+        $controllerMap = [
+            'Some\Other\Service\Namespace\Controller\Sample' => 'another/sample'
+        ];
+
+        $this->routeMatch->setParam('prefer_route_match_controller', true);
+        $this->routeMatch->setParam('controller', 'Some\Other\Service\Namespace\Controller\Sample');
+
+        $preferRouteMatchControllerRouteMatchConfig = $this->routeMatch->getParam('prefer_route_match_controller', false);
+        $this->listener->setPreferRouteMatchController($preferRouteMatchControllerRouteMatchConfig);
+        $this->listener->setControllerMap($controllerMap);
+
+        $myViewModel  = new ViewModel();
+        $myController = new \ZendTest\Mvc\Controller\TestAsset\SampleController();
+
+        $this->event->setTarget($myController);
+        $this->event->setResult($myViewModel);
+        $this->listener->injectTemplate($this->event);
+
+        $this->assertEquals('another/sample', $myViewModel->getTemplate());
+    }
 }


### PR DESCRIPTION
- InjectTemplateListener  - `injectTemplate` : set `$preferRouteMatchController` view config param if exists. This way apigility rest service can return proper view per api .
- prefer_route_match_controller should be set at the config route to true  :
  
  ``` php
  'route' => '/sales[/:sales_id]',
                  'defaults' => array(
                      'controller' => 'Ecommerce\\V1\\Rest\\Sales\\Controller',
                      'prefer_route_match_controller'=>true
                  ),
  ```
- `controller_map` should be set at the config `view_manager` also:
  
  ``` php
    'controller_map' => array(
          'Ecommerce\\V1\\Rest\\Sales\\Controller' => 'ecommerce/sales'
    ),
  ```
- AcceptableViewModelSelector - notice fix 
