### PR TITLE
InjectTemplateListener return proper api template

### DIFF
--- a/src/View/Http/InjectTemplateListener.php
+++ b/src/View/Http/InjectTemplateListener.php
@@ -69,7 +69,7 @@ class InjectTemplateListener extends AbstractListenerAggregate
         }
 
         $routeMatch = $e->getRouteMatch();
-        if($preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false)) {
+        if ($preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false)) {
             $this->setPreferRouteMatchController($preferRouteMatchController);
         }
 

--- a/src/View/Http/InjectTemplateListener.php
+++ b/src/View/Http/InjectTemplateListener.php
@@ -69,6 +69,10 @@ class InjectTemplateListener extends AbstractListenerAggregate
         }
 
         $routeMatch = $e->getRouteMatch();
+        if($preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false)){
+            $this->setPreferRouteMatchController($preferRouteMatchController);
+        }
+
         $controller = $e->getTarget();
         if (is_object($controller)) {
             $controller = get_class($controller);

--- a/src/View/Http/InjectTemplateListener.php
+++ b/src/View/Http/InjectTemplateListener.php
@@ -69,7 +69,7 @@ class InjectTemplateListener extends AbstractListenerAggregate
         }
 
         $routeMatch = $e->getRouteMatch();
-        if($preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false)){
+        if($preferRouteMatchController = $routeMatch->getParam('prefer_route_match_controller', false)) {
             $this->setPreferRouteMatchController($preferRouteMatchController);
         }
 

--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -360,7 +360,7 @@ class InjectTemplateListenerTest extends TestCase
         $this->event->setResult($myViewModel);
         $this->listener->injectTemplate($this->event);
 
-        $this->assertEquals('another/samle', $myViewModel->getTemplate());
+        $this->assertEquals('another/sample', $myViewModel->getTemplate());
     }
 
 }

--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -341,4 +341,26 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->assertEquals('some/sample', $myViewModel->getTemplate());
     }
+
+    public function testPrefersRouteMatchControllerWithRouteMatchAndControllerMap()
+    {
+        $this->assertFalse($this->listener->isPreferRouteMatchController());
+        $this->routeMatch->setParam('prefer_route_match_controller', true);
+        $this->routeMatch->setParam('controller', 'Some\Other\Service\Namespace\Controller\Sample');
+
+        $preferRouteMatchControllerRouteMatchConfig = $this->routeMatch->getParam('prefer_route_match_controller', false);
+        $this->listener->setPreferRouteMatchController($preferRouteMatchControllerRouteMatchConfig);
+        $this->listener->setControllerMap([
+                'Some\Other\Service\Namespace\Controller\Sample' => 'another/samle'
+        ]);
+        $myViewModel  = new ViewModel();
+        $myController = new \ZendTest\Mvc\Controller\TestAsset\SampleController();
+
+        $this->event->setTarget($myController);
+        $this->event->setResult($myViewModel);
+        $this->listener->injectTemplate($this->event);
+
+        $this->assertEquals('another/samle', $myViewModel->getTemplate());
+    }
+
 }

--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -365,5 +365,4 @@ class InjectTemplateListenerTest extends TestCase
 
         $this->assertEquals('another/sample', $myViewModel->getTemplate());
     }
-
 }

--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -351,7 +351,7 @@ class InjectTemplateListenerTest extends TestCase
         $preferRouteMatchControllerRouteMatchConfig = $this->routeMatch->getParam('prefer_route_match_controller', false);
         $this->listener->setPreferRouteMatchController($preferRouteMatchControllerRouteMatchConfig);
         $this->listener->setControllerMap([
-                'Some\Other\Service\Namespace\Controller\Sample' => 'another/samle'
+                'Some\Other\Service\Namespace\Controller\Sample' => 'another/sample'
         ]);
         $myViewModel  = new ViewModel();
         $myController = new \ZendTest\Mvc\Controller\TestAsset\SampleController();

--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -345,14 +345,17 @@ class InjectTemplateListenerTest extends TestCase
     public function testPrefersRouteMatchControllerWithRouteMatchAndControllerMap()
     {
         $this->assertFalse($this->listener->isPreferRouteMatchController());
+        $controllerMap = [
+            'Some\Other\Service\Namespace\Controller\Sample' => 'another/sample'
+        ];
+
         $this->routeMatch->setParam('prefer_route_match_controller', true);
         $this->routeMatch->setParam('controller', 'Some\Other\Service\Namespace\Controller\Sample');
 
         $preferRouteMatchControllerRouteMatchConfig = $this->routeMatch->getParam('prefer_route_match_controller', false);
         $this->listener->setPreferRouteMatchController($preferRouteMatchControllerRouteMatchConfig);
-        $this->listener->setControllerMap([
-                'Some\Other\Service\Namespace\Controller\Sample' => 'another/sample'
-        ]);
+        $this->listener->setControllerMap($controllerMap);
+
         $myViewModel  = new ViewModel();
         $myController = new \ZendTest\Mvc\Controller\TestAsset\SampleController();
 


### PR DESCRIPTION
InjectTemplateListener return proper api template if prefer_route_match_controller is set to true from route config.This way we can set controller_map and as a result ,apigility will return proper api template ,instead to look for template zf/rest/action.phtml ( get-list.phtml ) 

```
                'defaults' => array(
                    'controller' => 'Ecommerce\\V1\\Rest\\Sales\\Controller',
                    'prefer_route_match_controller' => true
                ),
```
