### PR TITLE
Use a factory to create the SendResponseListener

### DIFF
--- a/src/Service/SendResponseListenerFactory.php
+++ b/src/Service/SendResponseListenerFactory.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Service;
+
+use Interop\Container\ContainerInterface;
+use Zend\Mvc\SendResponseListener;
+
+class SendResponseListenerFactory
+{
+    /**
+     * @param ContainerInterface $container
+     * @return SendResponseListener
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        $listener = new SendResponseListener();
+        $listener->setEventManager($container->get('EventManager'));
+        return $listener;
+    }
+}

--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -86,7 +86,7 @@ class ServiceListenerFactory implements FactoryInterface
             'ViewPrefixPathStackResolver'    => 'Zend\Mvc\Service\ViewPrefixPathStackResolverFactory',
             'Zend\Mvc\MiddlewareListener'    => InvokableFactory::class,
             'Zend\Mvc\RouteListener'         => InvokableFactory::class,
-            'Zend\Mvc\SendResponseListener'  => InvokableFactory::class,
+            'Zend\Mvc\SendResponseListener'  => SendResponseListenerFactory::class,
             'Zend\View\Renderer\FeedRenderer' => InvokableFactory::class,
             'Zend\View\Renderer\JsonRenderer' => InvokableFactory::class,
             'Zend\View\Renderer\PhpRenderer' => ViewPhpRendererFactory::class,

--- a/test/Service/SendResponseFactoryTest.php
+++ b/test/Service/SendResponseFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\SharedEventManagerInterface;
+use Zend\Mvc\ResponseSender\HttpResponseSender;
+use Zend\Mvc\ResponseSender\PhpEnvironmentResponseSender;
+use Zend\Mvc\ResponseSender\SendResponseEvent;
+use Zend\Mvc\ResponseSender\SimpleStreamResponseSender;
+use Zend\Mvc\SendResponseListener;
+use Zend\Mvc\Service\SendResponseListenerFactory;
+
+class SendResponseFactoryTest extends TestCase
+{
+    public function testFactoryReturnsListenerWithEventManagerFromContainer()
+    {
+        $sharedEvents = $this->prophesize(SharedEventManagerInterface::class);
+        $events = $this->prophesize(EventManagerInterface::class);
+        $events->getSharedManager()->will([$sharedEvents, 'reveal']);
+
+        $events->setIdentifiers([SendResponseListener::class, SendResponseListener::class])->shouldBeCalled();
+        $events->attach(
+            SendResponseEvent::EVENT_SEND_RESPONSE,
+            Argument::type(PhpEnvironmentResponseSender::class),
+            -1000
+        )->shouldBeCalled();
+        $events->attach(
+            SendResponseEvent::EVENT_SEND_RESPONSE,
+            Argument::type(SimpleStreamResponseSender::class),
+            -3000
+        )->shouldBeCalled();
+        $events->attach(
+            SendResponseEvent::EVENT_SEND_RESPONSE,
+            Argument::type(HttpResponseSender::class),
+            -4000
+        )->shouldBeCalled();
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get('EventManager')->will([$events, 'reveal']);
+
+        $factory = new SendResponseListenerFactory();
+        $listener = $factory($container->reveal());
+        $this->assertInstanceOf(SendResponseListener::class, $listener);
+        $this->assertSame($events->reveal(), $listener->getEventManager());
+    }
+}


### PR DESCRIPTION
Reported in:
- zendframework/zend-mvc-console#10
- zendframework/zend-mvc-console#11
- zendframework/zend-mvc-console#12

The `SendResponseListener` was lazy-instantiating an event manager on first request to `getEventManager()`. However, because initializers run after delegators, this meant that the EM instance composed did not have a shared EM instance, which triggered the initializer to re-inject, losing any listeners injected by delegators.

This patch introduces a factory for the `SendResponseListener`. The factory creates the instance, and then injects it with an EM instance pulled from the container; since these are guaranteed to have a shared EM instance, the initializer will skip injection, keeping any listeners injected by delegators.
