### PR TITLE
Add route match params to request attributes

### DIFF
--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -14,6 +14,7 @@ use Zend\EventManager\AbstractListenerAggregate;
 use Zend\EventManager\EventManagerInterface;
 use Zend\Psr7Bridge\Psr7ServerRequest as Psr7Request;
 use Zend\Psr7Bridge\Psr7Response;
+use Zend\Router\RouteMatch;
 
 class MiddlewareListener extends AbstractListenerAggregate
 {
@@ -59,7 +60,7 @@ class MiddlewareListener extends AbstractListenerAggregate
 
         $caughtException = null;
         try {
-            $psr7Request = Psr7Request::fromZend($request);
+            $psr7Request = Psr7Request::fromZend($request)->withAttribute(RouteMatch::class, $routeMatch);
             foreach ($routeMatch->getParams() as $key => $value) {
                 $psr7Request = $psr7Request->withAttribute($key, $value);
             }

--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -59,7 +59,11 @@ class MiddlewareListener extends AbstractListenerAggregate
 
         $caughtException = null;
         try {
-            $return = $middleware(Psr7Request::fromZend($request), Psr7Response::fromZend($response));
+            $psr7Request = Psr7Request::fromZend($request);
+            foreach ($routeMatch->getParams() as $key => $value) {
+                $psr7Request = $psr7Request->withAttribute($key, $value);
+            }
+            $return = $middleware($psr7Request, Psr7Response::fromZend($response));
         } catch (\Throwable $ex) {
             $caughtException = $ex;
         } catch (\Exception $ex) {  // @TODO clean up once PHP 7 requirement is enforced

--- a/test/MiddlewareListenerTest.php
+++ b/test/MiddlewareListenerTest.php
@@ -29,7 +29,6 @@ class MiddlewareListenerTest extends TestCase
      */
     private $routeMatch;
 
-
     /**
      * Create an MvcEvent, populated with everything it needs.
      *
@@ -42,6 +41,7 @@ class MiddlewareListenerTest extends TestCase
         $response   = new Response();
         $this->routeMatch = $this->prophesize(RouteMatch::class);
         $this->routeMatch->getParam('middleware', false)->willReturn($middlewareMatched);
+        $this->routeMatch->getParams()->willReturn([]);
 
         $eventManager = new EventManager();
 
@@ -153,6 +153,7 @@ class MiddlewareListenerTest extends TestCase
         $response   = new Response();
         $routeMatch = $this->prophesize(RouteMatch::class);
         $routeMatch->getParam('middleware', false)->willReturn('test');
+        $routeMatch->getParams()->willReturn([]);
 
         $eventManager = new EventManager();
 


### PR DESCRIPTION
Proposed change copies the `RouteMatch` parameters into the PSR-7 `\Zend\Diactoros\ServerRequest` so that they may be referred to in a middleware that has been invoked by the `MiddlewareListener`. Currently, if using a middleware in this way, I don't see any other way to access the matched route information (specifically, matched route parameters from a segment route, e.g. `/:uuid` matches, but I can't access the `uuid` parameter anywhere in the middleware action).