### PR TITLE
Migration to latest zendframework/zend-form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-hydrator": "^1.1 || ^2.1",
-        "zendframework/zend-form": "^2.7",
+        "zendframework/zend-form": "^2.8",
         "zendframework/zend-stdlib": "^2.7.5 || ^3.0",
         "zendframework/zend-psr7bridge": "^0.2",
         "container-interop/container-interop": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-hydrator": "^1.1 || ^2.1",
-        "zendframework/zend-form": "^2.8",
+        "zendframework/zend-form": "^2.8.2",
         "zendframework/zend-stdlib": "^2.7.5 || ^3.0",
         "zendframework/zend-psr7bridge": "^0.2",
         "container-interop/container-interop": "^1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4426c8b988d640f73cf28e79abdde9eb",
-    "content-hash": "f98bd21f26f74693a5757438e657f1db",
+    "content-hash": "47c5daefbb54ab42b5cf47d35672201d",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -32,7 +31,7 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30 15:22:37"
+            "time": "2014-12-30T15:22:37+00:00"
         },
         {
             "name": "psr/http-message",
@@ -81,7 +80,7 @@
                 "request",
                 "response"
             ],
-            "time": "2015-05-04 20:22:00"
+            "time": "2015-05-04T20:22:00+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -131,7 +130,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-01-04 21:37:32"
+            "time": "2016-01-04T21:37:32+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -175,7 +174,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:37"
+            "time": "2015-06-03T14:05:37+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -229,7 +228,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-02-18 20:53:00"
+            "time": "2016-02-18T20:53:00+00:00"
         },
         {
             "name": "zendframework/zend-filter",
@@ -285,20 +284,20 @@
                 "filter",
                 "zf2"
             ],
-            "time": "2016-02-08 18:02:37"
+            "time": "2016-02-08T18:02:37+00:00"
         },
         {
             "name": "zendframework/zend-form",
-            "version": "2.7.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-form.git",
-                "reference": "7c46b6a2d04d12aacd9c32bb021d0d9d0354d5d5"
+                "reference": "ca2b2f9e1bdc5511d06967d755cbb793708a2d7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-form/zipball/7c46b6a2d04d12aacd9c32bb021d0d9d0354d5d5",
-                "reference": "7c46b6a2d04d12aacd9c32bb021d0d9d0354d5d5",
+                "url": "https://api.github.com/repos/zendframework/zend-form/zipball/ca2b2f9e1bdc5511d06967d755cbb793708a2d7b",
+                "reference": "ca2b2f9e1bdc5511d06967d755cbb793708a2d7b",
                 "shasum": ""
             },
             "require": {
@@ -309,43 +308,49 @@
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
+                "phpunit/phpunit": "^4.8",
                 "zendframework/zend-cache": "^2.6.1",
-                "zendframework/zend-captcha": "^2.5",
-                "zendframework/zend-code": "^2.6",
+                "zendframework/zend-captcha": "^2.7.1",
+                "zendframework/zend-code": "^2.6 || ^3.0",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-escaper": "^2.5",
                 "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
                 "zendframework/zend-filter": "^2.6",
                 "zendframework/zend-i18n": "^2.6",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-                "zendframework/zend-session": "^2.5",
+                "zendframework/zend-session": "^2.6.2",
                 "zendframework/zend-text": "^2.6",
                 "zendframework/zend-validator": "^2.6",
                 "zendframework/zend-view": "^2.6.2",
-                "zendframework/zendservice-recaptcha": "*"
+                "zendframework/zendservice-recaptcha": "^3.0.0"
             },
             "suggest": {
-                "zendframework/zend-captcha": "Zend\\Captcha component",
-                "zendframework/zend-code": "Zend\\Code component",
-                "zendframework/zend-eventmanager": "Zend\\EventManager component",
-                "zendframework/zend-filter": "Zend\\Filter component",
-                "zendframework/zend-i18n": "Zend\\I18n component",
-                "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
-                "zendframework/zend-validator": "Zend\\Validator component",
-                "zendframework/zend-view": "Zend\\View component",
-                "zendframework/zendservice-recaptcha": "ZendService\\ReCaptcha component"
+                "zendframework/zend-captcha": "^2.7.1, required for using CAPTCHA form elements",
+                "zendframework/zend-code": "^2.6 || ^3.0, required to use zend-form annotations support",
+                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0, reuired for zend-form annotations support",
+                "zendframework/zend-i18n": "^2.6, required when using zend-form view helpers",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3, required to use the form factories or provide services",
+                "zendframework/zend-view": "^2.6.2, required for using the zend-form view helpers",
+                "zendframework/zendservice-recaptcha": "in order to use the ReCaptcha form element"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev",
-                    "dev-develop": "2.8-dev"
+                    "dev-master": "2.10-dev",
+                    "dev-develop": "2.11-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Form",
+                    "config-provider": "Zend\\Form\\ConfigProvider"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Zend\\Form\\": "src/"
-                }
+                },
+                "files": [
+                    "autoload/formElementManagerPolyfill.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -356,7 +361,7 @@
                 "form",
                 "zf2"
             ],
-            "time": "2016-02-22 21:41:46"
+            "time": "2017-02-23T16:03:25+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -406,7 +411,7 @@
                 "http",
                 "zf2"
             ],
-            "time": "2016-02-04 20:36:48"
+            "time": "2016-02-04T20:36:48+00:00"
         },
         {
             "name": "zendframework/zend-hydrator",
@@ -464,7 +469,7 @@
                 "hydrator",
                 "zf2"
             ],
-            "time": "2016-02-18 22:31:17"
+            "time": "2016-02-18T22:31:17+00:00"
         },
         {
             "name": "zendframework/zend-inputfilter",
@@ -515,7 +520,7 @@
                 "inputfilter",
                 "zf2"
             ],
-            "time": "2016-02-18 19:49:24"
+            "time": "2016-02-18T19:49:24+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -559,7 +564,7 @@
                 "loader",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:47"
+            "time": "2015-06-03T14:05:47+00:00"
         },
         {
             "name": "zendframework/zend-psr7bridge",
@@ -608,7 +613,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2015-12-15 21:35:42"
+            "time": "2015-12-15T21:35:42+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -660,7 +665,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2016-02-02 14:13:42"
+            "time": "2016-02-02T14:13:42+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -705,7 +710,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-02-03 16:53:37"
+            "time": "2016-02-03T16:53:37+00:00"
         },
         {
             "name": "zendframework/zend-uri",
@@ -752,7 +757,7 @@
                 "uri",
                 "zf2"
             ],
-            "time": "2016-02-17 22:38:51"
+            "time": "2016-02-17T22:38:51+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -819,7 +824,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2016-02-17 17:59:34"
+            "time": "2016-02-17T17:59:34+00:00"
         }
     ],
     "packages-dev": [
@@ -875,7 +880,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -929,7 +934,7 @@
                 }
             ],
             "description": "A script to automatically fix Symfony Coding Standard",
-            "time": "2015-05-04 16:56:09"
+            "time": "2015-05-04T16:56:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -978,7 +983,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2015-02-03T12:10:50+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1040,7 +1045,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-02-15 07:46:21"
+            "time": "2016-02-15T07:46:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1102,7 +1107,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1149,7 +1154,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1190,7 +1195,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1231,7 +1236,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2015-06-21T08:01:12+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1280,7 +1285,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2015-09-15T10:49:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1352,7 +1357,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-02-11 14:56:33"
+            "time": "2016-02-11T14:56:33+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1408,7 +1413,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "psr/log",
@@ -1446,7 +1451,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2012-12-21T11:40:51+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1510,7 +1515,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2015-07-26T15:48:44+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1562,7 +1567,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1612,7 +1617,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-02-26 18:40:46"
+            "time": "2016-02-26T18:40:46+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1678,7 +1683,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2015-06-21T07:55:53+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1729,7 +1734,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1782,7 +1787,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1817,7 +1822,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/console",
@@ -1877,7 +1882,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-28 16:20:50"
+            "time": "2016-02-28T16:20:50+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1937,7 +1942,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-27 05:14:19"
+            "time": "2016-01-27T05:14:19+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1986,7 +1991,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-22 15:02:30"
+            "time": "2016-02-22T15:02:30+00:00"
         },
         {
             "name": "symfony/finder",
@@ -2035,7 +2040,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-22 16:12:45"
+            "time": "2016-02-22T16:12:45+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2094,7 +2099,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-01-20 09:13:37"
+            "time": "2016-01-20T09:13:37+00:00"
         },
         {
             "name": "symfony/process",
@@ -2143,7 +2148,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-02 13:33:15"
+            "time": "2016-02-02T13:33:15+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -2192,7 +2197,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-03 15:33:41"
+            "time": "2016-01-03T15:33:41+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2241,7 +2246,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-23 15:16:06"
+            "time": "2016-02-23T15:16:06+00:00"
         },
         {
             "name": "zendframework/zend-authentication",
@@ -2303,7 +2308,7 @@
                 "Authentication",
                 "zf2"
             ],
-            "time": "2016-02-28 15:02:34"
+            "time": "2016-02-28T15:02:34+00:00"
         },
         {
             "name": "zendframework/zend-cache",
@@ -2366,7 +2371,7 @@
                 "cache",
                 "zf2"
             ],
-            "time": "2016-02-12 16:26:56"
+            "time": "2016-02-12T16:26:56+00:00"
         },
         {
             "name": "zendframework/zend-code",
@@ -2419,7 +2424,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-01-26 17:57:25"
+            "time": "2016-01-26T17:57:25+00:00"
         },
         {
             "name": "zendframework/zend-console",
@@ -2471,7 +2476,7 @@
                 "console",
                 "zf2"
             ],
-            "time": "2016-02-09 17:15:12"
+            "time": "2016-02-09T17:15:12+00:00"
         },
         {
             "name": "zendframework/zend-di",
@@ -2518,7 +2523,7 @@
                 "di",
                 "zf2"
             ],
-            "time": "2016-02-23 20:38:54"
+            "time": "2016-02-23T20:38:54+00:00"
         },
         {
             "name": "zendframework/zend-i18n",
@@ -2581,7 +2586,7 @@
                 "i18n",
                 "zf2"
             ],
-            "time": "2016-02-10 22:29:02"
+            "time": "2016-02-10T22:29:02+00:00"
         },
         {
             "name": "zendframework/zend-json",
@@ -2636,7 +2641,7 @@
                 "json",
                 "zf2"
             ],
-            "time": "2016-02-04 21:20:26"
+            "time": "2016-02-04T21:20:26+00:00"
         },
         {
             "name": "zendframework/zend-log",
@@ -2700,7 +2705,7 @@
                 "logging",
                 "zf2"
             ],
-            "time": "2016-02-18 17:20:07"
+            "time": "2016-02-18T17:20:07+00:00"
         },
         {
             "name": "zendframework/zend-math",
@@ -2750,7 +2755,7 @@
                 "math",
                 "zf2"
             ],
-            "time": "2016-02-02 23:15:14"
+            "time": "2016-02-02T23:15:14+00:00"
         },
         {
             "name": "zendframework/zend-modulemanager",
@@ -2808,7 +2813,7 @@
                 "modulemanager",
                 "zf2"
             ],
-            "time": "2016-02-28 04:45:34"
+            "time": "2016-02-28T04:45:34+00:00"
         },
         {
             "name": "zendframework/zend-serializer",
@@ -2860,7 +2865,7 @@
                 "serializer",
                 "zf2"
             ],
-            "time": "2016-02-03 18:36:25"
+            "time": "2016-02-03T18:36:25+00:00"
         },
         {
             "name": "zendframework/zend-session",
@@ -2920,7 +2925,7 @@
                 "session",
                 "zf2"
             ],
-            "time": "2016-02-25 19:32:38"
+            "time": "2016-02-25T19:32:38+00:00"
         },
         {
             "name": "zendframework/zend-text",
@@ -2967,7 +2972,7 @@
                 "text",
                 "zf2"
             ],
-            "time": "2016-02-08 19:03:52"
+            "time": "2016-02-08T19:03:52+00:00"
         },
         {
             "name": "zendframework/zend-version",
@@ -3017,7 +3022,7 @@
                 "version",
                 "zf2"
             ],
-            "time": "2015-06-04 15:41:05"
+            "time": "2015-06-04T15:41:05+00:00"
         },
         {
             "name": "zendframework/zend-view",
@@ -3100,7 +3105,7 @@
                 "view",
                 "zf2"
             ],
-            "time": "2016-02-22 18:24:35"
+            "time": "2016-02-22T18:24:35+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "47c5daefbb54ab42b5cf47d35672201d",
+    "content-hash": "8ec5ccd19c612d81fa69a92ca7f0915f",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/src/Service/FormAnnotationBuilderFactory.php
+++ b/src/Service/FormAnnotationBuilderFactory.php
@@ -38,7 +38,7 @@ class FormAnnotationBuilderFactory implements FactoryInterface
 
         $formElementManager = $container->get('FormElementManager');
 
-        $this->prepareAndInjectFactory($formElementManager, $container, $annotationBuilder);
+        $this->injectFactory($formElementManager, $container, $annotationBuilder);
 
         $config = $container->get('config');
         if (isset($config['form_annotation_builder'])) {
@@ -82,13 +82,15 @@ class FormAnnotationBuilderFactory implements FactoryInterface
     }
 
     /**
+     * Handle zend-servicemanager dependent InitializerInterface signature
+     *
      * @param FormElementManagerV2Polyfill|FormElementManagerV3Polyfill $formElementManager
      * @param ContainerInterface                                        $container
      * @param AnnotationBuilder                                         $annotationBuilder
      *
      * @return void
      */
-    private function prepareAndInjectFactory(
+    private function injectFactory(
         $formElementManager,
         ContainerInterface $container,
         AnnotationBuilder $annotationBuilder

--- a/test/Service/FormAnnotationBuilderFactoryTest.php
+++ b/test/Service/FormAnnotationBuilderFactoryTest.php
@@ -10,23 +10,16 @@
 namespace ZendTest\Mvc\Service;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\EventManagerInterface;
 use Zend\Mvc\Service\FormAnnotationBuilderFactory;
 use Zend\ServiceManager\ServiceManager;
 
 class FormAnnotationBuilderFactoryTest extends TestCase
 {
-    public function setUp()
-    {
-        $this->markTestIncomplete('Re-enable once zend-form is migrated to zend-servicemanager v3');
-    }
-
     public function testCreateService()
     {
-        $mockElementManager = $this->getMock('Zend\Form\FormElementManager');
-
         $serviceLocator = new ServiceManager();
-        $serviceLocator->setService('FormElementManager', $mockElementManager);
-        $serviceLocator->setService('config', []);
+        $this->prepareServiceLocator($serviceLocator, []);
 
         $sut = new FormAnnotationBuilderFactory();
 
@@ -35,17 +28,38 @@ class FormAnnotationBuilderFactoryTest extends TestCase
 
     public function testCreateServiceSetsPreserveDefinedOrder()
     {
-        $mockElementManager = $this->getMock('Zend\Form\FormElementManager');
+
 
         $serviceLocator = new ServiceManager();
-        $serviceLocator->setService('FormElementManager', $mockElementManager);
         $config = ['form_annotation_builder' => ['preserve_defined_order' => true]];
-        $serviceLocator->setService('config', $config);
+        $this->prepareServiceLocator($serviceLocator, $config);
 
         $sut = new FormAnnotationBuilderFactory();
 
         $service = $sut->createService($serviceLocator);
 
         $this->assertTrue($service->preserveDefinedOrder(), 'Preserve defined order was not set correctly');
+    }
+
+    /**
+     * @param ServiceManager $manager
+     * @param array          $config
+     *
+     * @return void
+     */
+    private function prepareServiceLocator(ServiceManager $manager, array $config)
+    {
+        $mockElementManager = $this
+            ->getMockBuilder('Zend\Form\FormElementManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockEventManager = $this
+            ->getMockBuilder(EventManagerInterface::class)
+            ->getMock();
+
+        $manager->setService('config', $config);
+        $manager->setService('FormElementManager', $mockElementManager);
+        $manager->setService('EventManager', $mockEventManager);
     }
 }

--- a/test/Service/FormAnnotationBuilderFactoryTest.php
+++ b/test/Service/FormAnnotationBuilderFactoryTest.php
@@ -28,8 +28,6 @@ class FormAnnotationBuilderFactoryTest extends TestCase
 
     public function testCreateServiceSetsPreserveDefinedOrder()
     {
-
-
         $serviceLocator = new ServiceManager();
         $config = ['form_annotation_builder' => ['preserve_defined_order' => true]];
         $this->prepareServiceLocator($serviceLocator, $config);

--- a/test/Service/FormElementManagerFactoryTest.php
+++ b/test/Service/FormElementManagerFactoryTest.php
@@ -29,8 +29,6 @@ class FormElementManagerFactoryTest extends TestCase
 
     public function setUp()
     {
-        $this->markTestIncomplete('Re-enable once zend-form is migrated to zend-servicemanager v3');
-
         $formElementManagerFactory = new FormElementManagerFactory();
         $this->services = new ServiceManager([
             'factories' => [

--- a/test/Service/FormElementManagerFactoryTest.php
+++ b/test/Service/FormElementManagerFactoryTest.php
@@ -30,7 +30,7 @@ class FormElementManagerFactoryTest extends TestCase
     public function setUp()
     {
         $formElementManagerFactory = new FormElementManagerFactory();
-        $this->services = new ServiceManager([
+        $serviceManagerConfig = new Config([
             'factories' => [
                 'FormElementManager' => $formElementManagerFactory,
             ],
@@ -38,6 +38,10 @@ class FormElementManagerFactoryTest extends TestCase
                 'config' => [],
             ],
         ]);
+        $services = new ServiceManager();
+        $serviceManagerConfig->configureServiceManager($services);
+
+        $this->services = $services;
     }
 
     public function testWillGetFormElementManager()


### PR DESCRIPTION
There is an issue with the `zendframework/zend-form` ^2.8.2 since the `FormElementManagerV2Polyfill` has reverse order of `injectFactory` which does not work with `zendframework/zend-mvc` `FormAnnotationBuilderFactory`.