### PR TITLE
Ensure proper PHPDoc

### DIFF
--- a/src/Controller/AbstractActionController.php
+++ b/src/Controller/AbstractActionController.php
@@ -12,6 +12,7 @@ namespace Zend\Mvc\Controller;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mvc\Exception;
 use Zend\Mvc\MvcEvent;
+use Zend\View\Model\ConsoleModel;
 use Zend\View\Model\ViewModel;
 
 /**
@@ -39,7 +40,7 @@ abstract class AbstractActionController extends AbstractController
     /**
      * Action called if matched action does not exist
      *
-     * @return array
+     * @return ViewModel|ConsoleModel
      */
     public function notFoundAction()
     {

--- a/src/Controller/AbstractActionController.php
+++ b/src/Controller/AbstractActionController.php
@@ -52,7 +52,7 @@ abstract class AbstractActionController extends AbstractController
         if ($response instanceof HttpResponse) {
             return $this->createHttpNotFoundModel($response);
         }
-        return $this->createConsoleNotFoundModel($response);
+        return $this->createConsoleNotFoundModel();
     }
 
     /**
@@ -85,27 +85,5 @@ abstract class AbstractActionController extends AbstractController
         $e->setResult($actionResponse);
 
         return $actionResponse;
-    }
-
-    /**
-     * @deprecated please use the {@see \Zend\Mvc\Controller\Plugin\CreateHttpNotFoundModel} plugin instead: this
-     *             method will be removed in release 2.5 or later.
-     *
-     * {@inheritDoc}
-     */
-    protected function createHttpNotFoundModel(HttpResponse $response)
-    {
-        return $this->__call('createHttpNotFoundModel', [$response]);
-    }
-
-    /**
-     * @deprecated please use the {@see \Zend\Mvc\Controller\Plugin\CreateConsoleNotFoundModel} plugin instead: this
-     *             method will be removed in release 2.5 or later.
-     *
-     * {@inheritDoc}
-     */
-    protected function createConsoleNotFoundModel($response)
-    {
-        return $this->__call('createConsoleNotFoundModel', [$response]);
     }
 }

--- a/src/Controller/AbstractActionController.php
+++ b/src/Controller/AbstractActionController.php
@@ -28,7 +28,7 @@ abstract class AbstractActionController extends AbstractController
     /**
      * Default action if none provided
      *
-     * @return array
+     * @return ViewModel
      */
     public function indexAction()
     {
@@ -60,7 +60,8 @@ abstract class AbstractActionController extends AbstractController
      *
      * @param  MvcEvent $e
      * @return mixed
-     * @throws Exception\DomainException
+     *
+     * @throws Exception\DomainException If no RouteMatch was found within MvcEvent.
      */
     public function onDispatch(MvcEvent $e)
     {

--- a/src/Controller/AbstractActionController.php
+++ b/src/Controller/AbstractActionController.php
@@ -52,7 +52,7 @@ abstract class AbstractActionController extends AbstractController
         if ($response instanceof HttpResponse) {
             return $this->createHttpNotFoundModel($response);
         }
-        return $this->createConsoleNotFoundModel();
+        return $this->createConsoleNotFoundModel($response);
     }
 
     /**
@@ -86,5 +86,27 @@ abstract class AbstractActionController extends AbstractController
         $e->setResult($actionResponse);
 
         return $actionResponse;
+    }
+
+    /**
+     * @deprecated please use the {@see \Zend\Mvc\Controller\Plugin\CreateHttpNotFoundModel} plugin instead: this
+     *             method will be removed in release 2.5 or later.
+     *
+     * {@inheritDoc}
+     */
+    protected function createHttpNotFoundModel(HttpResponse $response)
+    {
+        return $this->__call('createHttpNotFoundModel', [$response]);
+    }
+
+    /**
+     * @deprecated please use the {@see \Zend\Mvc\Controller\Plugin\CreateConsoleNotFoundModel} plugin instead: this
+     *             method will be removed in release 2.5 or later.
+     *
+     * {@inheritDoc}
+     */
+    protected function createConsoleNotFoundModel($response)
+    {
+        return $this->__call('createConsoleNotFoundModel', [$response]);
     }
 }


### PR DESCRIPTION
Since always(?), the `AbstractActionController::notFoundAction` and the `AbstractActionController::indexAction` return `ViewModel`/`ConsoleModel` instead of `array`.

~~Aswell, I've removed deprecated methods which are already replaced by controller plugins aswell.~~