### PR TITLE
Fix: allow middleware dispatch to behave like controller dispatch

### DIFF
--- a/src/Controller/MiddlewareController.php
+++ b/src/Controller/MiddlewareController.php
@@ -57,32 +57,14 @@ final class MiddlewareController extends AbstractController
 
     /**
      * {@inheritDoc}
-     * @throws \Zend\Mvc\Exception\RuntimeException
+     *
+     * @throws RuntimeException
      */
     public function onDispatch(MvcEvent $e)
     {
-        $request  = $this->request;
-        $response = $this->response;
-
-        if (! $request instanceof Request) {
-            throw new RuntimeException(sprintf(
-                'Expected request to be a %s, %s given',
-                Request::class,
-                get_class($request)
-            ));
-        }
-
-        if (! $response instanceof Response) {
-            throw new RuntimeException(sprintf(
-                'Expected response to be a %s, %s given',
-                Response::class,
-                get_class($response)
-            ));
-        }
-
         $routeMatch  = $e->getRouteMatch();
         $psr7Request = $this->populateRequestParametersFromRoute(
-            Psr7ServerRequest::fromZend($request)->withAttribute(RouteMatch::class, $routeMatch),
+            $this->loadRequest()->withAttribute(RouteMatch::class, $routeMatch),
             $routeMatch
         );
 
@@ -96,6 +78,26 @@ final class MiddlewareController extends AbstractController
         $e->setResult($result);
 
         return $result;
+    }
+
+    /**
+     * @return \Zend\Diactoros\ServerRequest
+     *
+     * @throws RuntimeException
+     */
+    private function loadRequest()
+    {
+        $request = $this->request;
+
+        if (! $request instanceof Request) {
+            throw new RuntimeException(sprintf(
+                'Expected request to be a %s, %s given',
+                Request::class,
+                get_class($request)
+            ));
+        }
+
+        return Psr7ServerRequest::fromZend($request);
     }
 
     /**

--- a/src/Controller/MiddlewareController.php
+++ b/src/Controller/MiddlewareController.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Controller;
+
+use Zend\EventManager\EventManager;
+use Zend\Http\Request;
+use Zend\Http\Response;
+use Zend\Mvc\Exception\RuntimeException;
+use Zend\Mvc\MvcEvent;
+use Zend\Psr7Bridge\Psr7Response;
+use Zend\Psr7Bridge\Psr7ServerRequest;
+use Zend\Router\RouteMatch;
+
+/**
+ * Note: I'm a terrible person
+ *
+ * @internal don't use this in your codebase, or else @ocramius will hunt you down. This is just an internal
+ * @internal hack to make middleware trigger 'dispatch' events attached to the DispatchableInterface identifier.
+ */
+final class MiddlewareController extends AbstractController
+{
+    /**
+     * @var callable
+     */
+    private $middleware;
+
+    public function __construct(callable $middleware, EventManager $eventManager, MvcEvent $event)
+    {
+        $this->eventIdentifier = __CLASS__;
+        $this->middleware      = $middleware;
+
+        $this->setEventManager($eventManager);
+        $this->setEvent($event);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws \Zend\Mvc\Exception\RuntimeException
+     */
+    public function onDispatch(MvcEvent $e)
+    {
+        $request  = $this->request;
+        $response = $this->response;
+
+        if (! $request instanceof Request) {
+            throw new RuntimeException(sprintf(
+                'Expected request to be a %s, %s given',
+                Request::class,
+                get_class($request)
+            ));
+        }
+
+        if (! $response instanceof Response) {
+            throw new RuntimeException(sprintf(
+                'Expected response to be a %s, %s given',
+                Response::class,
+                get_class($response)
+            ));
+        }
+
+        $routeMatch  = $e->getRouteMatch();
+        $psr7Request = Psr7ServerRequest::fromZend($request)->withAttribute(RouteMatch::class, $routeMatch);
+
+        if ($routeMatch) {
+            foreach ($routeMatch->getParams() as $key => $value) {
+                $psr7Request = $psr7Request->withAttribute($key, $value);
+            }
+        }
+
+        $result = \call_user_func($this->middleware, $psr7Request, Psr7Response::fromZend($response));
+
+        $e->setResult($result);
+
+        return $result;
+    }
+}

--- a/src/Controller/MiddlewareController.php
+++ b/src/Controller/MiddlewareController.php
@@ -10,7 +10,6 @@
 namespace Zend\Mvc\Controller;
 
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Zend\EventManager\EventManager;
 use Zend\Http\Request;
 use Zend\Http\Response;
@@ -90,7 +89,7 @@ final class MiddlewareController extends AbstractController
         }
 
         $result = $this->pipe->process($psr7Request, new CallableDelegateDecorator(
-            function (ServerRequestInterface $request, ResponseInterface $response) {
+            function () {
                 throw ReachedFinalHandlerException::create();
             },
             $this->responsePrototype

--- a/src/Controller/MiddlewareController.php
+++ b/src/Controller/MiddlewareController.php
@@ -13,7 +13,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\EventManager\EventManager;
 use Zend\Http\Request;
-use Zend\Http\Response;
 use Zend\Mvc\Exception\ReachedFinalHandlerException;
 use Zend\Mvc\Exception\RuntimeException;
 use Zend\Mvc\MvcEvent;

--- a/src/Controller/MiddlewareController.php
+++ b/src/Controller/MiddlewareController.php
@@ -54,7 +54,6 @@ final class MiddlewareController extends AbstractController
 
         $this->setEventManager($eventManager);
         $this->setEvent($event);
-
     }
 
     /**

--- a/src/Controller/MiddlewareController.php
+++ b/src/Controller/MiddlewareController.php
@@ -11,7 +11,7 @@ namespace Zend\Mvc\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\EventManager\EventManager;
+use Zend\EventManager\EventManagerInterface;
 use Zend\Http\Request;
 use Zend\Mvc\Exception\ReachedFinalHandlerException;
 use Zend\Mvc\Exception\RuntimeException;
@@ -45,7 +45,7 @@ final class MiddlewareController extends AbstractController
     public function __construct(
         MiddlewarePipe $pipe,
         ResponseInterface $responsePrototype,
-        EventManager $eventManager,
+        EventManagerInterface $eventManager,
         MvcEvent $event
     ) {
         $this->eventIdentifier   = __CLASS__;

--- a/src/Controller/MiddlewareController.php
+++ b/src/Controller/MiddlewareController.php
@@ -17,7 +17,6 @@ use Zend\Http\Response;
 use Zend\Mvc\Exception\ReachedFinalHandlerException;
 use Zend\Mvc\Exception\RuntimeException;
 use Zend\Mvc\MvcEvent;
-use Zend\Psr7Bridge\Psr7Response;
 use Zend\Psr7Bridge\Psr7ServerRequest;
 use Zend\Router\RouteMatch;
 use Zend\Stratigility\Delegate\CallableDelegateDecorator;

--- a/src/Controller/MiddlewareController.php
+++ b/src/Controller/MiddlewareController.php
@@ -22,10 +22,13 @@ use Zend\Stratigility\Delegate\CallableDelegateDecorator;
 use Zend\Stratigility\MiddlewarePipe;
 
 /**
- * Note: I'm a terrible person
- *
  * @internal don't use this in your codebase, or else @ocramius will hunt you down. This is just an internal
  * @internal hack to make middleware trigger 'dispatch' events attached to the DispatchableInterface identifier.
+ *
+ * Specifically, it will receive a @see MiddlewarePipe, a @see ResponseInterface prototype, and then dispatch
+ * the pipe whilst still behaving like a normal controller. That is needed for any events attached to
+ * the @see \Zend\Stdlib\DispatchableInterface identifier to reach their listeners on any attached
+ * @see \Zend\EventManager\SharedEventManagerInterface
  */
 final class MiddlewareController extends AbstractController
 {

--- a/src/DispatchListener.php
+++ b/src/DispatchListener.php
@@ -76,6 +76,10 @@ class DispatchListener extends AbstractListenerAggregate
      */
     public function onDispatch(MvcEvent $e)
     {
+        if (null !== $e->getResult()) {
+            return;
+        }
+
         $routeMatch        = $e->getRouteMatch();
         $controllerName    = $routeMatch instanceof RouteMatch
             ? $routeMatch->getParam('controller', 'not-found')

--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -18,7 +18,7 @@ use Zend\EventManager\AbstractListenerAggregate;
 use Zend\EventManager\EventManagerInterface;
 use Zend\Mvc\Exception\InvalidMiddlewareException;
 use Zend\Mvc\Exception\ReachedFinalHandlerException;
-use Zend\Psr7Bridge\Psr7ServerRequest as Psr7Request;
+use Zend\Mvc\Controller\MiddlewareController;
 use Zend\Psr7Bridge\Psr7Response;
 use Zend\Router\RouteMatch;
 use Zend\Stratigility\Delegate\CallableDelegateDecorator;
@@ -78,6 +78,11 @@ class MiddlewareListener extends AbstractListenerAggregate
 
         $caughtException = null;
         try {
+            $return = (new MiddlewareController(
+                $middleware,
+                $application->getServiceManager()->get('EventManager'),
+                $event
+            ))->dispatch($request, $response);
             $psr7Request = Psr7Request::fromZend($request)->withAttribute(RouteMatch::class, $routeMatch);
             foreach ($routeMatch->getParams() as $key => $value) {
                 $psr7Request = $psr7Request->withAttribute($key, $value);

--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -107,6 +107,8 @@ class MiddlewareListener extends AbstractListenerAggregate
             }
         }
 
+        $event->setError('');
+
         if (! $return instanceof PsrResponseInterface) {
             $event->setResult($return);
             return $return;

--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -45,6 +45,10 @@ class MiddlewareListener extends AbstractListenerAggregate
      */
     public function onDispatch(MvcEvent $event)
     {
+        if (null !== $event->getResult()) {
+            return;
+        }
+
         $routeMatch = $event->getRouteMatch();
         $middleware = $routeMatch->getParam('middleware', false);
         if (false === $middleware) {

--- a/src/MiddlewareListener.php
+++ b/src/MiddlewareListener.php
@@ -83,20 +83,11 @@ class MiddlewareListener extends AbstractListenerAggregate
         $caughtException = null;
         try {
             $return = (new MiddlewareController(
-                $middleware,
+                $pipe,
+                $psr7ResponsePrototype,
                 $application->getServiceManager()->get('EventManager'),
                 $event
             ))->dispatch($request, $response);
-            $psr7Request = Psr7Request::fromZend($request)->withAttribute(RouteMatch::class, $routeMatch);
-            foreach ($routeMatch->getParams() as $key => $value) {
-                $psr7Request = $psr7Request->withAttribute($key, $value);
-            }
-            $return = $pipe->process($psr7Request, new CallableDelegateDecorator(
-                function (PsrServerRequestInterface $request, PsrResponseInterface $response) {
-                    throw ReachedFinalHandlerException::create();
-                },
-                $psr7ResponsePrototype
-            ));
         } catch (\Throwable $ex) {
             $caughtException = $ex;
         } catch (\Exception $ex) {  // @TODO clean up once PHP 7 requirement is enforced

--- a/test/Controller/MiddlewareControllerTest.php
+++ b/test/Controller/MiddlewareControllerTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use ReflectionProperty;
+use Zend\EventManager\EventManager;
+use Zend\EventManager\EventManagerAwareInterface;
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\ResponseCollection;
+use Zend\Http\Request;
+use Zend\Http\Response;
+use Zend\Mvc\Controller\AbstractController;
+use Zend\Mvc\Controller\MiddlewareController;
+use Zend\Mvc\InjectApplicationEventInterface;
+use Zend\Mvc\MvcEvent;
+use Zend\Stdlib\DispatchableInterface;
+use Zend\Stratigility\MiddlewarePipe;
+
+/**
+ * @covers \Zend\Mvc\Controller\MiddlewareController
+ */
+class MiddlewareControllerTest extends TestCase
+{
+    /**
+     * @var MiddlewarePipe|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $pipe;
+
+    /**
+     * @var ResponseInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $responsePrototype;
+
+    /**
+     * @var EventManagerInterface
+     */
+    private $eventManager;
+
+    /**
+     * @var AbstractController|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $controller;
+
+    /**
+     * @var MvcEvent
+     */
+    private $event;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->pipe              = $this->createMock(MiddlewarePipe::class);
+        $this->responsePrototype = $this->createMock(ResponseInterface::class);
+        $this->eventManager      = $this->createMock(EventManagerInterface::class);
+        $this->event             = new MvcEvent();
+        $this->eventManager      = new EventManager();
+
+        $this->controller = new MiddlewareController(
+            $this->pipe,
+            $this->responsePrototype,
+            $this->eventManager,
+            $this->event
+        );
+    }
+
+    public function testWillAssignCorrectEventManagerIdentifiers()
+    {
+        $identifiers = $this->eventManager->getIdentifiers();
+
+        self::assertContains(MiddlewareController::class, $identifiers);
+        self::assertContains(AbstractController::class, $identifiers);
+        self::assertContains(DispatchableInterface::class, $identifiers);
+    }
+
+    public function testWillDispatchARequestAndResponseWithAGivenPipe()
+    {
+        $request          = new Request();
+        $response         = new Response();
+        $result           = $this->createMock(ResponseInterface::class);
+        $dispatchListener = $this->getMockBuilder(\stdClass::class)->setMethods(['__invoke'])->getMock();
+
+        $this->eventManager->attach(MvcEvent::EVENT_DISPATCH, $dispatchListener, 100);
+        $this->eventManager->attach(MvcEvent::EVENT_DISPATCH_ERROR, function () {
+            self::fail('No dispatch error expected');
+        }, 100);
+
+        $dispatchListener
+            ->expects(self::once())
+            ->method('__invoke')
+            ->with(self::callback(function (MvcEvent $event) use ($request, $response) {
+                self::assertSame($this->event, $event);
+                self::assertSame(MvcEvent::EVENT_DISPATCH, $event->getName());
+                self::assertSame($this->controller, $event->getTarget());
+                self::assertSame($request, $event->getRequest());
+                self::assertSame($response, $event->getResponse());
+
+                return true;
+            }));
+
+        $this->pipe->expects(self::once())->method('process')->willReturn($result);
+
+        $controllerResult = $this->controller->dispatch($request, $response);
+
+        self::assertSame($result, $controllerResult);
+        self::assertSame($result, $this->event->getResult());
+    }
+}

--- a/test/Controller/MiddlewareControllerTest.php
+++ b/test/Controller/MiddlewareControllerTest.php
@@ -11,17 +11,13 @@ namespace ZendTest\Mvc\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
-use ReflectionProperty;
 use Zend\EventManager\EventManager;
-use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
-use Zend\EventManager\ResponseCollection;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Mvc\Controller\AbstractController;
 use Zend\Mvc\Controller\MiddlewareController;
 use Zend\Mvc\Exception\RuntimeException;
-use Zend\Mvc\InjectApplicationEventInterface;
 use Zend\Mvc\MvcEvent;
 use Zend\Stdlib\DispatchableInterface;
 use Zend\Stdlib\RequestInterface;

--- a/test/DispatchListenerTest.php
+++ b/test/DispatchListenerTest.php
@@ -19,6 +19,8 @@ use Zend\Mvc\DispatchListener;
 use Zend\Mvc\MvcEvent;
 use Zend\Router\RouteMatch;
 use Zend\ServiceManager\ServiceManager;
+use Zend\Stdlib\ResponseInterface;
+use Zend\View\Model\ModelInterface;
 
 class DispatchListenerTest extends TestCase
 {
@@ -82,5 +84,50 @@ class DispatchListenerTest extends TestCase
 
         $this->assertArrayHasKey('error', $log);
         $this->assertSame('error-controller-not-found', $log['error']);
+    }
+
+    /**
+     * @dataProvider alreadySetMvcEventResultProvider
+     *
+     * @param mixed $alreadySetResult
+     */
+    public function testWillNotDispatchWhenAnMvcEventResultIsAlreadySet($alreadySetResult)
+    {
+        $event = $this->createMvcEvent('path');
+
+        $event->setResult($alreadySetResult);
+
+        $listener = new DispatchListener(new ControllerManager(new ServiceManager(), ['abstract_factories' => [
+            Controller\TestAsset\UnlocatableControllerLoaderAbstractFactory::class,
+        ]]));
+
+        $event->getApplication()->getEventManager()->attach(MvcEvent::EVENT_DISPATCH_ERROR, function () {
+            self::fail('No dispatch failures should be raised - dispatch should be skipped');
+        });
+
+        $listener->onDispatch($event);
+
+        self::assertSame($alreadySetResult, $event->getResult(), 'The event result was not replaced');
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function alreadySetMvcEventResultProvider()
+    {
+        return [
+            [123],
+            [true],
+            [false],
+            [[]],
+            [new \stdClass()],
+            [$this],
+            [$this->createMock(ModelInterface::class)],
+            [$this->createMock(ResponseInterface::class)],
+            [$this->createMock(Response::class)],
+            [['view model data' => 'as an array']],
+            [['foo' => new \stdClass()]],
+            ['a response string'],
+        ];
     }
 }

--- a/test/MiddlewareListenerTest.php
+++ b/test/MiddlewareListenerTest.php
@@ -374,6 +374,6 @@ class MiddlewareListenerTest extends TestCase
 
         self::assertInstanceOf(Response::class, $result);
         self::assertInstanceOf(Response::class, $event->getResult());
-        self::assertNull($event->getError(), 'Previously set MVC errors are canceled by a successful dispatch');
+        self::assertEmpty($event->getError(), 'Previously set MVC errors are canceled by a successful dispatch');
     }
 }

--- a/test/MiddlewareListenerTest.php
+++ b/test/MiddlewareListenerTest.php
@@ -376,4 +376,67 @@ class MiddlewareListenerTest extends TestCase
         self::assertInstanceOf(Response::class, $event->getResult());
         self::assertEmpty($event->getError(), 'Previously set MVC errors are canceled by a successful dispatch');
     }
+
+    /**
+     * @dataProvider possibleMiddlewareNonPsr7ResponseReturnValues
+     *
+     * @param mixed $middlewareResult
+     */
+    public function testMiddlewareDispatchWillRetrieveAnyCallableReturnValue($middlewareResult)
+    {
+        $middlewareName = uniqid('middleware', true);
+        $routeMatch     = new RouteMatch(['middleware' => $middlewareName]);
+        /* @var $application Application|\PHPUnit_Framework_MockObject_MockObject */
+        $application    = $this->createMock(Application::class);
+        $serviceManager = $this->createMock(ServiceManager::class);
+        $eventManager   = new EventManager();
+        $middleware     = $this->getMockBuilder(\stdClass::class)->setMethods(['__invoke'])->getMock();
+
+        $application->expects(self::any())->method('getRequest')->willReturn(new Request());
+        $application->expects(self::any())->method('getEventManager')->willReturn($eventManager);
+        $application->expects(self::any())->method('getServiceManager')->willReturn($serviceManager);
+        $application->expects(self::any())->method('getResponse')->willReturn(new Response());
+        $middleware->expects(self::once())->method('__invoke')->willReturn($middlewareResult);
+
+        $serviceManager->expects(self::any())->method('has')->with($middlewareName)->willReturn(true);
+        $serviceManager->expects(self::any())->method('get')->with($middlewareName)->willReturn($middleware);
+
+        $eventManager->attach(MvcEvent::EVENT_DISPATCH_ERROR, function () {
+            self::fail('No dispatch error should have been raised');
+        });
+
+        $event = new MvcEvent();
+
+        $event->setRequest(new Request());
+        $event->setApplication($application);
+        $event->setError(Application::ERROR_CONTROLLER_CANNOT_DISPATCH);
+        $event->setRouteMatch($routeMatch);
+
+        $listener = new MiddlewareListener();
+        $result   = $listener->onDispatch($event);
+
+        self::assertSame($middlewareResult, $result);
+        self::assertSame($middlewareResult, $event->getResult());
+        self::assertEmpty($event->getError(), 'No errors raised when the return type is unknown');
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function possibleMiddlewareNonPsr7ResponseReturnValues()
+    {
+        return [
+            [123],
+            [true],
+            [false],
+            [[]],
+            [new \stdClass()],
+            [$this],
+            [$this->createMock(ModelInterface::class)],
+            [$this->createMock(Response::class)],
+            [['view model data' => 'as an array']],
+            [['foo' => new \stdClass()]],
+            ['a response string'],
+        ];
+    }
 }

--- a/test/MiddlewareListenerTest.php
+++ b/test/MiddlewareListenerTest.php
@@ -89,7 +89,6 @@ class MiddlewareListenerTest extends TestCase
         $application = $event->getApplication();
 
         $application->getEventManager()->attach(MvcEvent::EVENT_DISPATCH_ERROR, function ($e) {
-            die(var_dump($e->getParam('exception')->getMessage()));
             $this->fail(sprintf('dispatch.error triggered when it should not be: %s', var_export($e->getError(), 1)));
         });
 
@@ -163,6 +162,7 @@ class MiddlewareListenerTest extends TestCase
         $eventManager = new EventManager();
 
         $serviceManager = $this->prophesize(ContainerInterface::class);
+        $serviceManager->get('EventManager')->willReturn($eventManager);
         $serviceManager->has('firstMiddleware')->willReturn(true);
         $serviceManager->get('firstMiddleware')->willReturn(function ($request, $response, $next) {
             $this->assertInstanceOf(ServerRequestInterface::class, $request);
@@ -302,6 +302,8 @@ class MiddlewareListenerTest extends TestCase
             return $serviceManager->reveal();
         });
         $application->getResponse()->willReturn($response);
+
+        $serviceManager->get('EventManager')->willReturn($eventManager);
 
         $event = new MvcEvent();
         $event->setRequest(new Request());

--- a/test/MiddlewareListenerTest.php
+++ b/test/MiddlewareListenerTest.php
@@ -27,6 +27,7 @@ use Zend\Mvc\MiddlewareListener;
 use Zend\Mvc\MvcEvent;
 use Zend\Router\RouteMatch;
 use Zend\ServiceManager\ServiceManager;
+use Zend\View\Model\ModelInterface;
 
 class MiddlewareListenerTest extends TestCase
 {
@@ -344,8 +345,7 @@ class MiddlewareListenerTest extends TestCase
     public function testValidMiddlewareDispatchCancelsPreviousDispatchFailures()
     {
         $middlewareName = uniqid('middleware', true);
-        /* @var $routeMatch RouteMatch|\PHPUnit_Framework_MockObject_MockObject */
-        $routeMatch     = $this->createMock(RouteMatch::class);
+        $routeMatch     = new RouteMatch(['middleware' => $middlewareName]);
         $response       = new DiactorosResponse();
         /* @var $application Application|\PHPUnit_Framework_MockObject_MockObject */
         $application    = $this->createMock(Application::class);
@@ -361,8 +361,6 @@ class MiddlewareListenerTest extends TestCase
 
         $serviceManager->expects(self::any())->method('has')->with($middlewareName)->willReturn(true);
         $serviceManager->expects(self::any())->method('get')->with($middlewareName)->willReturn($middleware);
-        $routeMatch->expects(self::any())->method('getParam')->with('middleware')->willReturn($middlewareName);
-        $routeMatch->expects(self::any())->method('getParams')->willReturn([]);
 
         $event = new MvcEvent();
 

--- a/test/MiddlewareListenerTest.php
+++ b/test/MiddlewareListenerTest.php
@@ -425,7 +425,6 @@ class MiddlewareListenerTest extends TestCase
         $middleware->expects(self::once())->method('__invoke')->willReturn($middlewareResult);
 
         $eventManager->attach(MvcEvent::EVENT_DISPATCH_ERROR, function ($e) {
-            var_dump($e->getParam('exception')->getMessage());
             self::fail('No dispatch error should have been raised');
         });
 

--- a/test/MiddlewareListenerTest.php
+++ b/test/MiddlewareListenerTest.php
@@ -521,6 +521,7 @@ class MiddlewareListenerTest extends TestCase
         $routeMatch     = new RouteMatch(['middleware' => $middlewareName]);
         /* @var $application Application|\PHPUnit_Framework_MockObject_MockObject */
         $application    = $this->createMock(Application::class);
+        $eventManager   = new EventManager();
         $middleware     = $this->getMockBuilder(\stdClass::class)->setMethods(['__invoke'])->getMock();
         $serviceManager = new ServiceManager([
             'factories' => [
@@ -534,7 +535,7 @@ class MiddlewareListenerTest extends TestCase
         ]);
 
         $application->expects(self::any())->method('getRequest')->willReturn(new Request());
-        $application->expects(self::any())->method('getEventManager')->willReturn(new EventManager());
+        $application->expects(self::any())->method('getEventManager')->willReturn($eventManager);
         $application->expects(self::any())->method('getServiceManager')->willReturn($serviceManager);
         $application->expects(self::any())->method('getResponse')->willReturn(new Response());
         $middleware->expects(self::never())->method('__invoke');
@@ -548,6 +549,10 @@ class MiddlewareListenerTest extends TestCase
         $event->setRouteMatch($routeMatch);
 
         $listener = new MiddlewareListener();
+
+        $eventManager->attach(MvcEvent::EVENT_DISPATCH_ERROR, function () {
+            self::fail('No dispatch failures should be raised - dispatch should be skipped');
+        });
 
         $listener->onDispatch($event);
 

--- a/test/View/RouteNotFoundStrategyTest.php
+++ b/test/View/RouteNotFoundStrategyTest.php
@@ -23,6 +23,11 @@ class RouteNotFoundStrategyTest extends TestCase
 {
     use EventListenerIntrospectionTrait;
 
+    /**
+     * @var RouteNotFoundStrategy
+     */
+    private $strategy;
+
     public function setUp()
     {
         $this->strategy = new RouteNotFoundStrategy();


### PR DESCRIPTION
This patch makes sure that the successful dispatch of a middleware won't trigger exception and 404 strategies. This can happen when the return value of the `MiddlewareListener` is not a `Zend\Stdlib\ResponseInterface` instance, and therefore the `EventManager` will not short-circuit and stop event propagation. 

~~~This allows returning anything from a configured `middleware`:~~~

 * ~~~`['foo' => 'bar']`~~~
 * ~~~`'Hello World!'`~~~
 * ~~~`new ViewModel(['foo' => 'bar'])`~~~

~~~This also fixes https://github.com/zendframework/zendframework/issues/5806~~ ERRATA: it doesn't, as #217 now enforces middleware to return `ResponseInterface` instances.

~~~I'm still stuck on this though. As per tradition `Zend\Mvc\ViewManager` is being absolutely useless, and [attaches all listeners to the shared manager `DispatchableInterface` identifier](https://github.com/zendframework/zend-mvc/blob/2c64d2ed50063e13b23f1c7e19f17ce3354bea36/src/View/Http/ViewManager.php#L124-L152): that means that basically nothing in the view layer works when using this stuff.~~~

~~~Currently preparing a workaround that triggers events that have the `DispatchableInterface` identifier, since otherwise it is impossible to get this thing running correctly.~~~