### PR TITLE
allowing more event identifiers in AbstractController

### DIFF
--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -155,7 +155,9 @@ abstract class AbstractController implements
         ];
 
         $offset = 0;
-        for ($i = 0; $i < substr_count($className, '\\'); $i++) {
+        $substrCont = substr_count($className, '\\');
+
+        for ($i = 0; $i < $substrCont; $i++) {
             $nsPos = strpos($className, '\\', $offset) ?: 0;
             $namespace = substr($className, 0, $nsPos);
             $offset = strlen($namespace) + 1;

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -149,14 +149,21 @@ abstract class AbstractController implements
     public function setEventManager(EventManagerInterface $events)
     {
         $className = get_class($this);
+        $identifierList = [
+            __CLASS__,
+            $className,
+        ];
 
-        $nsPos = strpos($className, '\\') ?: 0;
+        $offset = 0;
+        for ($i = 0; $i < substr_count($className, '\\'); $i++) {
+            $nsPos = strpos($className, '\\', $offset) ?: 0;
+            $namespace = substr($className, 0, $nsPos);
+            $offset = strlen($namespace) + 1;
+            $identifierList[] = $namespace;
+        }
+
         $events->setIdentifiers(array_merge(
-            [
-                __CLASS__,
-                $className,
-                substr($className, 0, $nsPos)
-            ],
+            $identifierList,
             array_values(class_implements($className)),
             (array) $this->eventIdentifier
         ));

--- a/test/Controller/ActionControllerTest.php
+++ b/test/Controller/ActionControllerTest.php
@@ -10,13 +10,14 @@
 namespace ZendTest\Mvc\Controller;
 
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
+use Zend\EventManager as ZendEventManager;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\SharedEventManager;
 use Zend\EventManager\SharedEventManagerInterface;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Mvc\Controller\AbstractActionController;
+use Zend\Mvc\Controller\AbstractController;
 use Zend\Mvc\Controller\Plugin\Url;
 use Zend\Mvc\Controller\PluginManager;
 use Zend\Mvc\InjectApplicationEventInterface;
@@ -30,10 +31,18 @@ use ZendTest\Mvc\Controller\TestAsset\SampleInterface;
 
 class ActionControllerTest extends TestCase
 {
-    public $controller;
-    public $event;
-    public $request;
-    public $response;
+    /** @var  SampleController */
+    protected $controller;
+    /** @var  MvcEvent */
+    protected $event;
+    /** @var  Request */
+    protected $request;
+    /** @var  null */
+    protected $response;
+    /** @var  RouteMatch */
+    protected $routeMatch;
+    /** @var  EventManager */
+    protected $events;
 
     public function setUp()
     {
@@ -45,13 +54,13 @@ class ActionControllerTest extends TestCase
         $this->event->setRouteMatch($this->routeMatch);
         $this->controller->setEvent($this->event);
 
-        $this->sharedEvents = new SharedEventManager();
-        $this->events       = $this->createEventManager($this->sharedEvents);
+        $sharedEvents = new SharedEventManager();
+        $this->events = $this->createEventManager($sharedEvents);
         $this->controller->setEventManager($this->events);
     }
 
     /**
-     * @param SharedEventManager
+     * @param SharedEventManagerInterface $sharedManager
      * @return EventManager
      */
     protected function createEventManager(SharedEventManagerInterface $sharedManager)
@@ -221,5 +230,29 @@ class ActionControllerTest extends TestCase
         $model = $this->event->getViewModel();
         $this->controller->layout('alternate/layout');
         $this->assertEquals('alternate/layout', $model->getTemplate());
+    }
+
+    public function testSetEventManagerIdentifiers()
+    {
+        $identifierList = $this->events->getIdentifiers();
+        $this->assertInternalType('array', $identifierList);
+        $this->assertCount(12, $identifierList);
+        $this->assertSame(
+            [
+                AbstractController::class,
+                TestAsset\SampleController::class,
+                'ZendTest',
+                'ZendTest\Mvc',
+                'ZendTest\Mvc\Controller',
+                'ZendTest\Mvc\Controller\TestAsset',
+                DispatchableInterface::class,
+                ZendEventManager\EventManagerAwareInterface::class,
+                ZendEventManager\EventsCapableInterface::class,
+                InjectApplicationEventInterface::class,
+                TestAsset\SampleInterface::class,
+                AbstractActionController::class,
+            ],
+            $identifierList
+        );
     }
 }


### PR DESCRIPTION
hi =)

my main problem was like https://github.com/zendframework/zendframework/pull/6553, but with a other namespace of my module.

i had 2 modules which has following names `Foobar\Baz` and `Foobar\Bar`, with the old logic it was not possible to know which controller module was called. It was everytime just `Foobar` in the event identifiers.

With the change it will generate a list with different namespaces so it will generate `Foobar`, `Foobar\Baz` or `Foobar\Bar`.