### PR TITLE
RESTful: Handle single field request with empty value

### DIFF
--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -22,8 +22,6 @@ abstract class AbstractRestfulController extends AbstractController
 {
     const CONTENT_TYPE_JSON = 'json';
 
-    const CONTENT_TYPE_X_WWW_FORM_URL_ENCODED = 'x-www-form-urlencoded';
-
     /**
      * {@inheritDoc}
      */
@@ -36,9 +34,6 @@ abstract class AbstractRestfulController extends AbstractController
         self::CONTENT_TYPE_JSON => [
             'application/hal+json',
             'application/json'
-        ],
-        self::CONTENT_TYPE_X_WWW_FORM_URL_ENCODED => [
-            'application/x-www-form-urlencoded'
         ]
     ];
 
@@ -604,8 +599,7 @@ abstract class AbstractRestfulController extends AbstractController
         }
 
         // If we have a single element with empty value
-        if (1 == count($parsedParams) && '' === reset($parsedParams)
-            && ! $this->requestHasContentType($request, self::CONTENT_TYPE_X_WWW_FORM_URL_ENCODED)) {
+        if (count($parsedParams) === 1 && reset($parsedParams) === '' && substr($content, -1) !== '=') {
             return $content;
         }
 

--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -598,12 +598,12 @@ abstract class AbstractRestfulController extends AbstractController
 
         parse_str($content, $parsedParams);
 
-        // If parse_str fails to decode, or we have a single element with empty value
+        // If parse_str fails to decode
         if (! is_array($parsedParams) || empty($parsedParams)) {
             return $content;
         }
 
-        // If have a single element with empty value
+        // If we have a single element with empty value
         if (1 == count($parsedParams) && '' === reset($parsedParams)
             && ! $this->requestHasContentType($request, self::CONTENT_TYPE_X_WWW_FORM_URL_ENCODED)) {
             return $content;

--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -22,6 +22,8 @@ abstract class AbstractRestfulController extends AbstractController
 {
     const CONTENT_TYPE_JSON = 'json';
 
+    const CONTENT_TYPE_X_WWW_FORM_URL_ENCODED = 'x-www-form-urlencoded';
+
     /**
      * {@inheritDoc}
      */
@@ -34,6 +36,9 @@ abstract class AbstractRestfulController extends AbstractController
         self::CONTENT_TYPE_JSON => [
             'application/hal+json',
             'application/json'
+        ],
+        self::CONTENT_TYPE_X_WWW_FORM_URL_ENCODED => [
+            'application/x-www-form-urlencoded'
         ]
     ];
 
@@ -594,9 +599,13 @@ abstract class AbstractRestfulController extends AbstractController
         parse_str($content, $parsedParams);
 
         // If parse_str fails to decode, or we have a single element with empty value
-        if (! is_array($parsedParams) || empty($parsedParams)
-            || (1 == count($parsedParams) && '' === reset($parsedParams))
-        ) {
+        if (! is_array($parsedParams) || empty($parsedParams)) {
+            return $content;
+        }
+
+        // If have a single element with empty value
+        if (1 == count($parsedParams) && '' === reset($parsedParams)
+            && ! $this->requestHasContentType($request, self::CONTENT_TYPE_X_WWW_FORM_URL_ENCODED)) {
             return $content;
         }
 

--- a/test/Controller/RestfulControllerTest.php
+++ b/test/Controller/RestfulControllerTest.php
@@ -561,4 +561,29 @@ class RestfulControllerTest extends TestCase
             ['PUT',     json_encode(['foo' => 1]),      []],          // AbstractRestfulController::replaceList()
         ];
     }
+
+    /**
+     * @dataProvider providerParseSingleFieldObjectWithEmptyValueProvider
+     */
+    public function testParseSingleFieldObjectWithEmptyValue($method)
+    {
+        $entity = ['name' => ''];
+        $string = http_build_query($entity);
+        $this->request->setMethod($method)
+            ->setContent($string);
+        $this->request->getHeaders()->addHeaderLine('Content-type', 'application/x-www-form-urlencoded');
+        $this->routeMatch->setParam('id', 1);
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $test = $result['entity'];
+        $this->assertArrayHasKey('name', $test);
+        $this->assertEquals('', $test['name']);
+    }
+
+    public function providerParseSingleFieldObjectWithEmptyValueProvider()
+    {
+        return [
+            ['PUT'],
+            ['PATCH']
+        ];
+    }
 }

--- a/test/Controller/TestAsset/RestfulContentTypeTestController.php
+++ b/test/Controller/TestAsset/RestfulContentTypeTestController.php
@@ -27,4 +27,19 @@ class RestfulContentTypeTestController extends AbstractRestfulController
             'data' => $data,
         ];
     }
+
+    /**
+     * Patch an existing resource
+     *
+     * @param  mixed $id
+     * @param  mixed $data
+     * @return array
+     */
+    public function patch($id, $data)
+    {
+        return [
+            'id' => $id,
+            'data' => $data,
+        ];
+    }
 }


### PR DESCRIPTION
`Controller/AbstractRestfulController`

There is no way to PUT/PATCH object with single field to empty value.

```
PUT /item/1
Content-Type: application/x-www-form-urlencoded

name=
```

Request payload is interpreted as string (`$data = 'name=';`) regardless Content-Type.
Proper value is `$data = ['name' => ''];`


I think ideally is split behaviour by Content-Type but that follows to huge BC. (see [testCanReceiveStringAsRequestContent](/zendframework/zend-mvc/blob/master/test/Controller/RestfulControllerTest.php#L103))

My pull request handle just one situation (example above) by header.