### PR TITLE
Bugfix strtolower template name

### DIFF
--- a/src/View/Http/InjectTemplateListener.php
+++ b/src/View/Http/InjectTemplateListener.php
@@ -157,7 +157,7 @@ class InjectTemplateListener extends AbstractListenerAggregate
         }
 
         $name = preg_replace($pattern, $replacement, $name);
-        return strtolower($name);
+        return mb_strtolower($name);
     }
 
     /**


### PR DESCRIPTION
Hi,

When i install Zend Framework 3 on ubuntu or ubuntu based operating systems, an exception new pages, "cannot resolve Application/Index/index" template. I found this bug's fix. I think, this problem occured so UTF-8.