### PR TITLE
Detach InjectViewModelListener before forwarding.

### DIFF
--- a/src/Controller/Plugin/Forward.php
+++ b/src/Controller/Plugin/Forward.php
@@ -184,15 +184,11 @@ class Forward extends AbstractPlugin
                 foreach ($events as $priority => $currentPriorityEvents) {
                     foreach ($currentPriorityEvents as $currentEvent) {
                         $currentCallback = $currentEvent;
-
-                        // If we have an array, grab the object
-                        if (is_array($currentCallback)) {
-                            $currentCallback = array_shift($currentCallback);
-                        }
-
-                        // This routine is only valid for object callbacks
-                        if (! is_object($currentCallback)) {
-                            continue;
+                        foreach ($classArray as $class) {
+                            if (isset($currentCallback[0]) && $currentCallback[0] instanceof $class) {
+                                $sharedEvents->detach($currentEvent);
+                                $results[$id][$eventName][$priority] = $currentCallback;
+                            }
                         }
                     }
                 }

--- a/test/Controller/Plugin/ForwardTest.php
+++ b/test/Controller/Plugin/ForwardTest.php
@@ -237,6 +237,25 @@ class ForwardTest extends TestCase
         $this->assertEquals(['content' => 'ZendTest\Mvc\Controller\TestAsset\ForwardController::testAction'], $result);
     }
 
+    public function testDetachmentOfInjectViewModelListener()
+    {
+        $services = $this->services;
+        $events   = $services->get('EventManager');
+        $sharedEvents = $this->createMock(SharedEventManagerInterface::class);
+        $callback = [$this->createMock('Zend\Mvc\View\Http\InjectViewModelListener'), 'injectViewModel'];
+        $sharedEvents->expects($this->any())->method('getListeners')->will($this->returnValue([
+            [$callback]
+        ]));
+        $sharedEvents->expects($this->once())->method('detach')->with($this->equalTo($callback));
+        $events = $this->createEventManager($sharedEvents);
+        $application = $this->createMock(ApplicationInterface::class);
+        $application->expects($this->any())->method('getEventManager')->will($this->returnValue($events));
+        $event = $this->controller->getEvent();
+        $event->setApplication($application);
+
+        $result = $this->plugin->dispatch('forward');
+    }
+
     public function testDispatchWillSeedRouteMatchWithPassedParameters()
     {
         $result = $this->plugin->dispatch('forward', [


### PR DESCRIPTION
A long time ago, this commit was introduced to the Forward plugin: https://github.com/zendframework/zendframework/commit/0b8fc7adb6b138feec99eaff8e7a2ef4fe6aa041. This prevents a problem where forwarding causes multiple InjectViewModelListeners to get attached, which in turn causes the view template to get rendered multiple times. This is a waste of cycles, and in some cases causes malfunctions (in situations where rendering a template has side effects).

It appears that somewhere along the line, this functionality was broken and the test intended to cover it was removed. This PR restores the broken functionality and adds a test to help catch future regressions.

Real life use case: my application has a "flash messages" view helper which checks the session for pending messages, displays them, and then clears the queue from the session. This bug prevents flash messages from displaying whenever the application performs a forward action, since the first render clears the queue, then the second render overwrites the first with no flash message data. For me, this is a critical bug.

Please let me know if there are any questions or if I can help to further refine this code. Thank you!