### PR TITLE
Typo fixed in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Fixed
 
 - [#247](https://github.com/zendframework/zend-mvc/pull/247) fixes bug in
-  controller plugin Forward, introduced in 2.1.0, where problem listeners were
+  controller plugin Forward, introduced in 3.1.0, where problem listeners were
   not detached for forwarded controller dispatch
 
 ## 3.1.0 - 2017-05-01


### PR DESCRIPTION
I think the issue was introduced in version 3.1.0, not 2.1.0.

**Please fix it also in release notes for [3.1.1](https://github.com/zendframework/zend-mvc/releases/tag/release-3.1.1)**