### PR TITLE
Use callable type hint instead of a comment

### DIFF
--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -527,7 +527,7 @@ abstract class AbstractRestfulController extends AbstractController
      * @param  Callable $handler
      * @return AbstractRestfulController
      */
-    public function addHttpMethodHandler($method, /* Callable */ $handler)
+    public function addHttpMethodHandler($method, callable $handler)
     {
         if (! is_callable($handler)) {
             throw new Exception\InvalidArgumentException(sprintf(


### PR DESCRIPTION
Use callable type hint instead of a comment