### PR TITLE
remove commented code at ServiceManagerConfig::configureServiceManager()

### DIFF
--- a/src/Service/ServiceManagerConfig.php
+++ b/src/Service/ServiceManagerConfig.php
@@ -123,35 +123,6 @@ class ServiceManagerConfig extends Config
     {
         $this->config['services'][ServiceManager::class] = $services;
 
-        /*
-        printf("Configuration prior to configuring servicemanager:\n");
-        foreach ($this->config as $type => $list) {
-            switch ($type) {
-                case 'aliases':
-                case 'delegators':
-                case 'factories':
-                case 'invokables':
-                case 'lazy_services':
-                case 'services':
-                case 'shared':
-                    foreach (array_keys($list) as $name) {
-                        printf("    %s (%s)\n", $name, $type);
-                    }
-                    break;
-
-                case 'initializers':
-                case 'abstract_factories':
-                    foreach ($list as $callable) {
-                        printf("    %s (%s)\n", (is_object($callable) ? get_class($callable) : $callable), $type);
-                    }
-                    break;
-
-                default:
-                    break;
-            }
-        }
-         */
-
         // This is invoked as part of the bootstrapping process, and requires
         // the ability to override services.
         $services->setAllowOverride(true);


### PR DESCRIPTION
- [x] Is this related to quality assurance?