### PR TITLE
Move unnecessary processBodyContent()

### DIFF
--- a/src/Controller/AbstractRestfulController.php
+++ b/src/Controller/AbstractRestfulController.php
@@ -347,13 +347,14 @@ abstract class AbstractRestfulController extends AbstractController
             // DELETE
             case 'delete':
                 $id = $this->getIdentifier($routeMatch, $request);
-                $data = $this->processBodyContent($request);
 
                 if ($id !== false) {
                     $action = 'delete';
                     $return = $this->delete($id);
                     break;
                 }
+
+                $data   = $this->processBodyContent($request);
 
                 $action = 'deleteList';
                 $return = $this->deleteList($data);


### PR DESCRIPTION
this commit copies the changes from davidwindell in 3.1.1 to the 2.7 branch.

not only for the performance but also because of the php7 problem of json_decode on an empty string.