### PR TITLE
Add full namespace identifier for controller events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Added
 
 - [#297](https://github.com/zendframework/zend-mvc/pull/297) adds support for PHP 7.3.
+- [#282](https://github.com/zendframework/zend-mvc/pull/282) Adds a full
+  controller namespace as additional event manager identifier for
+  implementations of AbstractController
 
 ### Deprecated
 

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -148,13 +148,19 @@ abstract class AbstractController implements
     {
         $className = get_class($this);
 
-        $nsPos = strpos($className, '\\') ?: 0;
+        $identifiers = [
+            __CLASS__,
+            $className,
+        ];
+
+        $rightmostNsPos = strrpos($className, '\\');
+        if ($rightmostNsPos) {
+            $identifiers[] = strstr($className, '\\', true); // top namespace
+            $identifiers[] = substr($className, 0, $rightmostNsPos); // full namespace
+        }
+
         $events->setIdentifiers(array_merge(
-            [
-                __CLASS__,
-                $className,
-                substr($className, 0, $nsPos)
-            ],
+            $identifiers,
             array_values(class_implements($className)),
             (array) $this->eventIdentifier
         ));

--- a/test/Controller/AbstractControllerTest.php
+++ b/test/Controller/AbstractControllerTest.php
@@ -14,6 +14,7 @@ use Zend\EventManager\EventManagerInterface;
 use Zend\Mvc\Controller\AbstractController;
 use Zend\Mvc\InjectApplicationEventInterface;
 use Zend\Stdlib\DispatchableInterface;
+use ZendTest\Mvc\Controller\TestAsset\AbstractControllerStub;
 
 /**
  * @covers \Zend\Mvc\Controller\AbstractController
@@ -30,7 +31,7 @@ class AbstractControllerTest extends TestCase
      */
     protected function setUp()
     {
-        $this->controller = $this->getMockForAbstractClass(AbstractController::class);
+        $this->controller = new AbstractControllerStub();
     }
 
     /**
@@ -103,6 +104,24 @@ class AbstractControllerTest extends TestCase
                 $this->contains(EventManagerAwareInterface::class),
                 $this->contains(DispatchableInterface::class),
                 $this->contains(InjectApplicationEventInterface::class)
+            ));
+
+        $this->controller->setEventManager($eventManager);
+    }
+
+    public function testSetEventManagerWithDefaultIdentifiersIncludesExtendingClassNameAndNamespace()
+    {
+        /* @var $eventManager EventManagerInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $eventManager = $this->createMock(EventManagerInterface::class);
+
+        $eventManager
+            ->expects($this->once())
+            ->method('setIdentifiers')
+            ->with($this->logicalAnd(
+                $this->contains(AbstractController::class),
+                $this->contains(AbstractControllerStub::class),
+                $this->contains('ZendTest'),
+                $this->contains('ZendTest\\Mvc\\Controller\\TestAsset')
             ));
 
         $this->controller->setEventManager($eventManager);

--- a/test/Controller/TestAsset/AbstractControllerStub.php
+++ b/test/Controller/TestAsset/AbstractControllerStub.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mvc for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-mvc/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Mvc\Controller\TestAsset;
+
+use Zend\Mvc\Controller\AbstractController;
+use Zend\Mvc\MvcEvent;
+
+class AbstractControllerStub extends AbstractController
+{
+    public function onDispatch(MvcEvent $e)
+    {
+        // noop
+    }
+}


### PR DESCRIPTION
- [x] Are you creating a new feature?

This pull request adds one extra identifier for controller events: full namespace of the controller class.
For the controller `Foo\BarModule\Controller\BazController` will result in `Foo\BarModule\Controller`.
It is in addition to top level namespace identifier that already exists (`Foo`).

This pull request is an alternative to #248 