### PR TITLE
Minor comment update

### DIFF
--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -71,12 +71,15 @@ class ControllerManager extends AbstractPluginManager
     /**
      * Initializer: inject EventManager instance
      *
-     * If we have an event manager composed already, make sure it gets injected
-     * with the shared event manager.
+     * Set a new event manager injected with the shared event manager.
      *
-     * The AbstractController lazy-instantiates an EM instance, which is why
-     * the shared EM injection needs to happen; the conditional will always
-     * pass.
+     * The AbstractController lazy-instantiates an EventManager instance,
+     * which is why the SharedEventManager injection needs to happen; the
+     * conditional will always pass.
+     *
+     * This works because we fetch the EventManager via the container
+     * (ServiceManager).  So it gets built by the EventManagerFactory,
+     * which injects the SharedEventManager via EventManager's constructor.
      *
      * @param ContainerInterface $container
      * @param DispatchableInterface $controller

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -71,12 +71,15 @@ class ControllerManager extends AbstractPluginManager
     /**
      * Initializer: inject EventManager instance
      *
-     * If we have an event manager composed already, make sure it gets injected
-     * with the shared event manager.
+     * Make sure the event manager gets injected with the shared event manager.
      *
-     * The AbstractController lazy-instantiates an EM instance, which is why
-     * the shared EM injection needs to happen; the conditional will always
-     * pass.
+     * The AbstractController lazy-instantiates an EventManager instance,
+     * which is why the SharedEventManager injection needs to happen; the
+     * conditional will always pass.
+     *
+     * This works because we fetch the EventManager via the container
+     * (ServiceManager).  So it gets built by the EventManagerFactory,
+     * which injects the SharedEventManager via EventManager's constructor.
      *
      * @param ContainerInterface $container
      * @param DispatchableInterface $controller

--- a/src/Controller/ControllerManager.php
+++ b/src/Controller/ControllerManager.php
@@ -71,7 +71,7 @@ class ControllerManager extends AbstractPluginManager
     /**
      * Initializer: inject EventManager instance
      *
-     * Make sure the event manager gets injected with the shared event manager.
+     * Set a new event manager injected with the shared event manager.
      *
      * The AbstractController lazy-instantiates an EventManager instance,
      * which is why the SharedEventManager injection needs to happen; the


### PR DESCRIPTION
The statement in `injectEventManager`'s comments that a shared event manager is injected into an existing event manager is incorrect - the code replaces the existing event manager with a new one.  That's what I updated.

I may have added too much 'how it works' detail, but I puzzled over this a bit so I thought the explanation might help future readers.
