### PR TITLE
Added FQCN aliases to `ServiceListenerFactory` so some could use e.g. ReflectionBasedAbstractFactories

### DIFF
--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -8,13 +8,36 @@
 namespace Zend\Mvc\Service;
 
 use Interop\Container\ContainerInterface;
+use Zend\Http\Request;
+use Zend\Http\Response;
 use Zend\ModuleManager\Listener\ServiceListener;
 use Zend\ModuleManager\Listener\ServiceListenerInterface;
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\Mvc\Controller\PluginManager;
+use Zend\Mvc\DispatchListener;
+use Zend\Mvc\HttpMethodListener;
+use Zend\Mvc\MiddlewareListener;
+use Zend\Mvc\RouteListener;
+use Zend\Mvc\SendResponseListener;
 use Zend\Mvc\View;
+use Zend\Mvc\View\Http\DefaultRenderingStrategy;
+use Zend\Mvc\View\Http\ExceptionStrategy;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\View\Renderer\FeedRenderer;
+use Zend\View\Renderer\JsonRenderer;
+use Zend\View\Renderer\PhpRenderer;
+use Zend\View\Renderer\RendererInterface;
+use Zend\View\Resolver\AggregateResolver;
+use Zend\View\Resolver\PrefixPathStackResolver;
+use Zend\View\Resolver\ResolverInterface;
+use Zend\View\Resolver\TemplateMapResolver;
+use Zend\View\Resolver\TemplatePathStack;
+use Zend\View\Strategy\FeedStrategy;
+use Zend\View\Strategy\JsonStrategy;
+use Zend\View\Strategy\PhpRendererStrategy;
 
 class ServiceListenerFactory implements FactoryInterface
 {
@@ -39,58 +62,71 @@ class ServiceListenerFactory implements FactoryInterface
             'Config'                                     => 'config',
             'configuration'                              => 'config',
             'Configuration'                              => 'config',
-            'HttpDefaultRenderingStrategy'               => View\Http\DefaultRenderingStrategy::class,
-            'MiddlewareListener'                         => 'Zend\Mvc\MiddlewareListener',
+            'HttpDefaultRenderingStrategy'               => DefaultRenderingStrategy::class,
+            'MiddlewareListener'                         => MiddlewareListener::class,
             'request'                                    => 'Request',
             'response'                                   => 'Response',
-            'RouteListener'                              => 'Zend\Mvc\RouteListener',
-            'SendResponseListener'                       => 'Zend\Mvc\SendResponseListener',
-            'View'                                       => 'Zend\View\View',
-            'ViewFeedRenderer'                           => 'Zend\View\Renderer\FeedRenderer',
-            'ViewJsonRenderer'                           => 'Zend\View\Renderer\JsonRenderer',
-            'ViewPhpRendererStrategy'                    => 'Zend\View\Strategy\PhpRendererStrategy',
-            'ViewPhpRenderer'                            => 'Zend\View\Renderer\PhpRenderer',
-            'ViewRenderer'                               => 'Zend\View\Renderer\PhpRenderer',
-            'Zend\Mvc\Controller\PluginManager'          => 'ControllerPluginManager',
-            'Zend\Mvc\View\Http\InjectTemplateListener'  => 'InjectTemplateListener',
-            'Zend\View\Renderer\RendererInterface'       => 'Zend\View\Renderer\PhpRenderer',
-            'Zend\View\Resolver\TemplateMapResolver'     => 'ViewTemplateMapResolver',
-            'Zend\View\Resolver\TemplatePathStack'       => 'ViewTemplatePathStack',
-            'Zend\View\Resolver\AggregateResolver'       => 'ViewResolver',
-            'Zend\View\Resolver\ResolverInterface'       => 'ViewResolver',
+            'RouteListener'                              => RouteListener::class,
+            'SendResponseListener'                       => SendResponseListener::class,
+            'View'                                       => \Zend\View\View::class,
+            'ViewFeedRenderer'                           => FeedRenderer::class,
+            'ViewJsonRenderer'                           => JsonRenderer::class,
+            'ViewPhpRendererStrategy'                    => PhpRendererStrategy::class,
+            'ViewPhpRenderer'                            => PhpRenderer::class,
+            'ViewRenderer'                               => PhpRenderer::class,
+            PluginManager::class                         => 'ControllerPluginManager',
+            View\Http\InjectTemplateListener::class      => 'InjectTemplateListener',
+            RendererInterface::class                     => PhpRenderer::class,
+            TemplateMapResolver::class                   => 'ViewTemplateMapResolver',
+            TemplatePathStack::class                     => 'ViewTemplatePathStack',
+            AggregateResolver::class                     => 'ViewResolver',
+            ResolverInterface::class                     => 'ViewResolver',
+            ControllerManager::class                     => 'ControllerManager',
+            DispatchListener::class                      => 'DispatchListener',
+            ExceptionStrategy::class                     => 'HttpExceptionStrategy',
+            HttpMethodListener::class                    => 'HttpMethodListener',
+            View\Http\RouteNotFoundStrategy::class       => 'HttpRouteNotFoundStrategy',
+            View\Http\ViewManager::class                 => 'HttpViewManager',
+            Request::class                               => 'Request',
+            Response::class                              => 'Response',
+            FeedStrategy::class                          => 'ViewFeedStrategy',
+            JsonStrategy::class                          => 'ViewJsonStrategy',
+            View\Http\ViewManager::class                 => 'ViewManager',
+            ResolverInterface::class                     => 'ViewResolver',
+            PrefixPathStackResolver::class               => 'ViewPrefixPathStackResolver',
         ],
         'invokables' => [],
         'factories'  => [
             'Application'                    => ApplicationFactory::class,
-            'config'                         => 'Zend\Mvc\Service\ConfigFactory',
-            'ControllerManager'              => 'Zend\Mvc\Service\ControllerManagerFactory',
-            'ControllerPluginManager'        => 'Zend\Mvc\Service\ControllerPluginManagerFactory',
-            'DispatchListener'               => 'Zend\Mvc\Service\DispatchListenerFactory',
+            'config'                         => ConfigFactory::class,
+            'ControllerManager'              => ControllerManagerFactory::class,
+            'ControllerPluginManager'        => ControllerPluginManagerFactory::class,
+            'DispatchListener'               => DispatchListenerFactory::class,
             'HttpExceptionStrategy'          => HttpExceptionStrategyFactory::class,
-            'HttpMethodListener'             => 'Zend\Mvc\Service\HttpMethodListenerFactory',
+            'HttpMethodListener'             => HttpMethodListenerFactory::class,
             'HttpRouteNotFoundStrategy'      => HttpRouteNotFoundStrategyFactory::class,
-            'HttpViewManager'                => 'Zend\Mvc\Service\HttpViewManagerFactory',
-            'InjectTemplateListener'         => 'Zend\Mvc\Service\InjectTemplateListenerFactory',
-            'PaginatorPluginManager'         => 'Zend\Mvc\Service\PaginatorPluginManagerFactory',
-            'Request'                        => 'Zend\Mvc\Service\RequestFactory',
-            'Response'                       => 'Zend\Mvc\Service\ResponseFactory',
-            'ViewHelperManager'              => 'Zend\Mvc\Service\ViewHelperManagerFactory',
-            View\Http\DefaultRenderingStrategy::class => HttpDefaultRenderingStrategyFactory::class,
-            'ViewFeedStrategy'               => 'Zend\Mvc\Service\ViewFeedStrategyFactory',
-            'ViewJsonStrategy'               => 'Zend\Mvc\Service\ViewJsonStrategyFactory',
-            'ViewManager'                    => 'Zend\Mvc\Service\ViewManagerFactory',
-            'ViewResolver'                   => 'Zend\Mvc\Service\ViewResolverFactory',
-            'ViewTemplateMapResolver'        => 'Zend\Mvc\Service\ViewTemplateMapResolverFactory',
-            'ViewTemplatePathStack'          => 'Zend\Mvc\Service\ViewTemplatePathStackFactory',
-            'ViewPrefixPathStackResolver'    => 'Zend\Mvc\Service\ViewPrefixPathStackResolverFactory',
-            'Zend\Mvc\MiddlewareListener'    => InvokableFactory::class,
-            'Zend\Mvc\RouteListener'         => InvokableFactory::class,
-            'Zend\Mvc\SendResponseListener'  => SendResponseListenerFactory::class,
-            'Zend\View\Renderer\FeedRenderer' => InvokableFactory::class,
-            'Zend\View\Renderer\JsonRenderer' => InvokableFactory::class,
-            'Zend\View\Renderer\PhpRenderer' => ViewPhpRendererFactory::class,
-            'Zend\View\Strategy\PhpRendererStrategy' => ViewPhpRendererStrategyFactory::class,
-            'Zend\View\View'                 => ViewFactory::class,
+            'HttpViewManager'                => HttpViewManagerFactory::class,
+            'InjectTemplateListener'         => InjectTemplateListenerFactory::class,
+            'PaginatorPluginManager'         => PaginatorPluginManagerFactory::class,
+            'Request'                        => RequestFactory::class,
+            'Response'                       => ResponseFactory::class,
+            'ViewHelperManager'              => ViewHelperManagerFactory::class,
+            DefaultRenderingStrategy::class  => HttpDefaultRenderingStrategyFactory::class,
+            'ViewFeedStrategy'               => ViewFeedStrategyFactory::class,
+            'ViewJsonStrategy'               => ViewJsonStrategyFactory::class,
+            'ViewManager'                    => ViewManagerFactory::class,
+            'ViewResolver'                   => ViewResolverFactory::class,
+            'ViewTemplateMapResolver'        => ViewTemplateMapResolverFactory::class,
+            'ViewTemplatePathStack'          => ViewTemplatePathStackFactory::class,
+            'ViewPrefixPathStackResolver'    => ViewPrefixPathStackResolverFactory::class,
+            MiddlewareListener::class        => InvokableFactory::class,
+            RouteListener::class             => InvokableFactory::class,
+            SendResponseListener::class      => SendResponseListenerFactory::class,
+            FeedRenderer::class              => InvokableFactory::class,
+            JsonRenderer::class              => InvokableFactory::class,
+            PhpRenderer::class               => ViewPhpRendererFactory::class,
+            PhpRendererStrategy::class       => ViewPhpRendererStrategyFactory::class,
+            \Zend\View\View::class           => ViewFactory::class,
         ],
     ];
 

--- a/src/Service/ServiceListenerFactory.php
+++ b/src/Service/ServiceListenerFactory.php
@@ -91,8 +91,6 @@ class ServiceListenerFactory implements FactoryInterface
             Response::class                              => 'Response',
             FeedStrategy::class                          => 'ViewFeedStrategy',
             JsonStrategy::class                          => 'ViewJsonStrategy',
-            View\Http\ViewManager::class                 => 'ViewManager',
-            ResolverInterface::class                     => 'ViewResolver',
             PrefixPathStackResolver::class               => 'ViewPrefixPathStackResolver',
         ],
         'invokables' => [],

--- a/test/Application/BadControllerTrait.php
+++ b/test/Application/BadControllerTrait.php
@@ -54,12 +54,8 @@ trait BadControllerTrait
         $serviceConfig = ArrayUtils::merge(
             $serviceConfig,
             [
-                'aliases' => [
-                    'ControllerLoader'  => ControllerManager::class,
-                    'ControllerManager' => ControllerManager::class,
-                ],
                 'factories' => [
-                    ControllerManager::class => function ($services) {
+                    'ControllerManager' => function ($services) {
                         return new ControllerManager($services, ['factories' => [
                             'bad' => function () {
                                 return new BadController();
@@ -71,8 +67,6 @@ trait BadControllerTrait
                     },
                 ],
                 'invokables' => [
-                    'Request'              => Request::class,
-                    'Response'             => Response::class,
                     'ViewManager'          => TestAsset\MockViewManager::class,
                     'SendResponseListener' => TestAsset\MockSendResponseListener::class,
                     'BootstrapListener'    => TestAsset\StubBootstrapListener::class,

--- a/test/Application/PathControllerTrait.php
+++ b/test/Application/PathControllerTrait.php
@@ -52,12 +52,8 @@ trait PathControllerTrait
         $serviceConfig = ArrayUtils::merge(
             $serviceConfig,
             [
-                'aliases' => [
-                    'ControllerLoader'  => ControllerManager::class,
-                    'ControllerManager' => ControllerManager::class,
-                ],
                 'factories' => [
-                    ControllerManager::class => function ($services) {
+                    'ControllerManager' => function ($services) {
                         return new ControllerManager($services, ['factories' => [
                             'path' => function () {
                                 return new TestAsset\PathController();
@@ -69,8 +65,6 @@ trait PathControllerTrait
                     },
                 ],
                 'invokables' => [
-                    'Request'              => Request::class,
-                    'Response'             => Response::class,
                     'ViewManager'          => TestAsset\MockViewManager::class,
                     'SendResponseListener' => TestAsset\MockSendResponseListener::class,
                     'BootstrapListener'    => TestAsset\StubBootstrapListener::class,

--- a/test/Service/ServiceListenerFactoryTest.php
+++ b/test/Service/ServiceListenerFactoryTest.php
@@ -8,13 +8,28 @@
 namespace ZendTest\Mvc\Service;
 
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 use ReflectionProperty;
-use Zend\ModuleManager\Listener\ServiceListener;
+use Zend\Http\Request;
+use Zend\Http\Response;
 use Zend\Mvc\Controller\ControllerManager;
+use Zend\Mvc\Controller\PluginManager;
+use Zend\Mvc\DispatchListener;
+use Zend\Mvc\HttpMethodListener;
 use Zend\Mvc\Service\ServiceListenerFactory;
+use Zend\Mvc\View\Http\ExceptionStrategy;
+use Zend\Mvc\View\Http\InjectTemplateListener;
+use Zend\Mvc\View\Http\RouteNotFoundStrategy;
+use Zend\Mvc\View\Http\ViewManager;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
+use Zend\View\Renderer\RendererInterface;
+use Zend\View\Resolver\AggregateResolver;
+use Zend\View\Resolver\PrefixPathStackResolver;
+use Zend\View\Resolver\ResolverInterface;
+use Zend\View\Resolver\TemplateMapResolver;
+use Zend\View\Resolver\TemplatePathStack;
+use Zend\View\Strategy\FeedStrategy;
+use Zend\View\Strategy\JsonStrategy;
 
 class ServiceListenerFactoryTest extends TestCase
 {
@@ -31,9 +46,9 @@ class ServiceListenerFactoryTest extends TestCase
 
     public function setUp()
     {
-        $sm = $this->sm = $this->getMockBuilder(ServiceManager::class)
-                               ->setMethods(['get'])
-                               ->getMock();
+        $this->sm = $this->getMockBuilder(ServiceManager::class)
+            ->setMethods(['get'])
+            ->getMock();
 
         $this->factory  = new ServiceListenerFactory();
     }
@@ -207,13 +222,30 @@ class ServiceListenerFactoryTest extends TestCase
         $services = new ServiceManager();
         $config->configureServiceManager($services);
 
-        $this->assertTrue($services->has($fqcn));
+        $this->assertTrue($services->has($fqcn), sprintf('Missing alias/factory/invokable for "%s"', $fqcn));
     }
 
     public function fullQualifiedClassNameProvider()
     {
         return [
-            'controller_manager' => [ControllerManager::class],
+            'PluginManager' => [PluginManager::class],
+            'InjectTemplateListener' => [InjectTemplateListener::class],
+            'RendererInterface' => [RendererInterface::class],
+            'TemplateMapResolver' => [TemplateMapResolver::class],
+            'TemplatePathStack' => [TemplatePathStack::class],
+            'AggregateResolver' => [AggregateResolver::class],
+            'ResolverInterface' => [ResolverInterface::class],
+            'ControllerManager' => [ControllerManager::class],
+            'DispatchListener' => [DispatchListener::class],
+            'ExceptionStrategy' => [ExceptionStrategy::class],
+            'HttpMethodListener' => [HttpMethodListener::class],
+            'RouteNotFoundStrategy' => [RouteNotFoundStrategy::class],
+            'ViewManager' => [ViewManager::class],
+            'Request' => [Request::class],
+            'Response' => [Response::class],
+            'FeedStrategy' => [FeedStrategy::class],
+            'JsonStrategy' => [JsonStrategy::class],
+            'PrefixPathStackResolver' => [PrefixPathStackResolver::class],
         ];
     }
 }

--- a/test/Service/ServiceListenerFactoryTest.php
+++ b/test/Service/ServiceListenerFactoryTest.php
@@ -214,7 +214,7 @@ class ServiceListenerFactoryTest extends TestCase
     /**
      * @dataProvider fullQualifiedClassNameProvider
      */
-    public function testWillProvideProperAliasesForLazyAbstractFactories($fqcn)
+    public function testWillProvideProperAliasesForReflectionBasedAbstractFactories($fqcn)
     {
         $configProperty = (new ReflectionProperty(ServiceListenerFactory::class, 'defaultServiceConfig'));
         $configProperty->setAccessible(true);


### PR DESCRIPTION
The `ServiceListenerFactory` is actually missing some aliases.
I've added the missing ones and fixed the old unit tests which provided non-matching configuration to the unit test either.

For ZF4 we should consider switching the FQCN to the `factories` and moving the old strings to the `aliases` configuration.