### PR TITLE
Force coverage annotations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
+         forceCoversAnnotation="true"
          colors="true">
     <testsuites>
         <testsuite name="zend-mvc Test Suite">

--- a/test/Application/AllowsReturningEarlyFromRoutingTest.php
+++ b/test/Application/AllowsReturningEarlyFromRoutingTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 use Zend\Http\PhpEnvironment\Response;
 use Zend\Mvc\MvcEvent;
 
+/**
+ * @coversNothing
+ */
 class AllowsReturningEarlyFromRoutingTest extends TestCase
 {
     use PathControllerTrait;

--- a/test/Application/ControllerIsDispatchedTest.php
+++ b/test/Application/ControllerIsDispatchedTest.php
@@ -12,6 +12,9 @@ namespace ZendTest\Mvc\Application;
 use PHPUnit\Framework\TestCase;
 use Zend\Mvc\MvcEvent;
 
+/**
+ * @coversNothing
+ */
 class ControllerIsDispatchedTest extends TestCase
 {
     use PathControllerTrait;

--- a/test/Application/ExceptionsRaisedInDispatchableShouldRaiseDispatchErrorEventTest.php
+++ b/test/Application/ExceptionsRaisedInDispatchableShouldRaiseDispatchErrorEventTest.php
@@ -12,6 +12,9 @@ namespace ZendTest\Mvc\Application;
 use PHPUnit\Framework\TestCase;
 use Zend\Mvc\MvcEvent;
 
+/**
+ * @coversNothing
+ */
 class ExceptionsRaisedInDispatchableShouldRaiseDispatchErrorEventTest extends TestCase
 {
     use BadControllerTrait;

--- a/test/Application/InabilityToRetrieveControllerShouldTriggerDispatchErrorTest.php
+++ b/test/Application/InabilityToRetrieveControllerShouldTriggerDispatchErrorTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
 
+/**
+ * @coversNothing
+ */
 class InabilityToRetrieveControllerShouldTriggerDispatchErrorTest extends TestCase
 {
     use MissingControllerTrait;

--- a/test/Application/InabilityToRetrieveControllerShouldTriggerExceptionTest.php
+++ b/test/Application/InabilityToRetrieveControllerShouldTriggerExceptionTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
 
+/**
+ * @coversNothing
+ */
 class InabilityToRetrieveControllerShouldTriggerExceptionTest extends TestCase
 {
     use MissingControllerTrait;

--- a/test/Application/InitializationIntegrationTest.php
+++ b/test/Application/InitializationIntegrationTest.php
@@ -16,6 +16,9 @@ use Zend\Mvc\MvcEvent;
 use function ob_get_clean;
 use function ob_start;
 
+/**
+ * @coversNothing
+ */
 class InitializationIntegrationTest extends TestCase
 {
     public function testDefaultInitializationWorkflow()

--- a/test/Application/InvalidControllerTypeShouldTriggerDispatchErrorTest.php
+++ b/test/Application/InvalidControllerTypeShouldTriggerDispatchErrorTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
 
+/**
+ * @coversNothing
+ */
 class InvalidControllerTypeShouldTriggerDispatchErrorTest extends TestCase
 {
     use InvalidControllerTypeTrait;

--- a/test/Application/RoutingSuccessTest.php
+++ b/test/Application/RoutingSuccessTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 use Zend\Mvc\MvcEvent;
 use Zend\Router\RouteMatch;
 
+/**
+ * @coversNothing
+ */
 class RoutingSuccessTest extends TestCase
 {
     use PathControllerTrait;

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -39,6 +39,9 @@ use function is_array;
 use function sprintf;
 use function var_export;
 
+/**
+ * @covers \Zend\Mvc\Application
+ */
 class ApplicationTest extends TestCase
 {
     use EventListenerIntrospectionTrait;

--- a/test/Controller/ActionControllerTest.php
+++ b/test/Controller/ActionControllerTest.php
@@ -31,6 +31,9 @@ use function get_class;
 use function method_exists;
 use function var_export;
 
+/**
+ * @covers \Zend\Mvc\Controller\AbstractActionController
+ */
 class ActionControllerTest extends TestCase
 {
     public $controller;

--- a/test/Controller/ControllerManagerTest.php
+++ b/test/Controller/ControllerManagerTest.php
@@ -21,6 +21,9 @@ use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
 
+/**
+ * @covers \Zend\Mvc\Controller\ControllerManager
+ */
 class ControllerManagerTest extends TestCase
 {
     public function setUp() : void

--- a/test/Controller/IntegrationTest.php
+++ b/test/Controller/IntegrationTest.php
@@ -17,6 +17,9 @@ use Zend\Mvc\Controller\PluginManager;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 
+/**
+ * @coversNothing
+ */
 class IntegrationTest extends TestCase
 {
     public function setUp() : void

--- a/test/Controller/LazyControllerAbstractFactoryTest.php
+++ b/test/Controller/LazyControllerAbstractFactoryTest.php
@@ -17,6 +17,9 @@ use Zend\Validator\ValidatorPluginManager;
 
 use function sprintf;
 
+/**
+ * @covers \Zend\Mvc\Controller\LazyControllerAbstractFactory
+ */
 class LazyControllerAbstractFactoryTest extends TestCase
 {
     public function setUp() : void

--- a/test/Controller/Plugin/AcceptableViewModelSelectorTest.php
+++ b/test/Controller/Plugin/AcceptableViewModelSelectorTest.php
@@ -18,6 +18,9 @@ use Zend\Mvc\MvcEvent;
 use Zend\View\Model;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
 
+/**
+ * @covers \Zend\Mvc\Controller\Plugin\AcceptableViewModelSelector
+ */
 class AcceptableViewModelSelectorTest extends TestCase
 {
     public function setUp() : void

--- a/test/Controller/Plugin/ForwardTest.php
+++ b/test/Controller/Plugin/ForwardTest.php
@@ -34,6 +34,9 @@ use ZendTest\Mvc\Controller\TestAsset\ForwardController;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
 use ZendTest\Mvc\Controller\TestAsset\UneventfulController;
 
+/**
+ * @covers \Zend\Mvc\Controller\Plugin\Forward
+ */
 class ForwardTest extends TestCase
 {
     /** @var ControllerManager */

--- a/test/Controller/Plugin/LayoutTest.php
+++ b/test/Controller/Plugin/LayoutTest.php
@@ -16,6 +16,9 @@ use Zend\Mvc\MvcEvent;
 use Zend\View\Model\ViewModel;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
 
+/**
+ * @covers \Zend\Mvc\Controller\Plugin\Layout
+ */
 class LayoutTest extends TestCase
 {
     public function setUp() : void

--- a/test/Controller/Plugin/ParamsTest.php
+++ b/test/Controller/Plugin/ParamsTest.php
@@ -21,6 +21,9 @@ use function uniqid;
 
 use const UPLOAD_ERR_OK;
 
+/**
+ * @covers \Zend\Mvc\Controller\Plugin\Params
+ */
 class ParamsTest extends TestCase
 {
     public function setUp() : void

--- a/test/Controller/Plugin/RedirectTest.php
+++ b/test/Controller/Plugin/RedirectTest.php
@@ -21,6 +21,9 @@ use Zend\Router\RouteMatch;
 use Zend\Router\SimpleRouteStack;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
 
+/**
+ * @covers \Zend\Mvc\Controller\Plugin\Redirect
+ */
 class RedirectTest extends TestCase
 {
     public function setUp() : void

--- a/test/Controller/Plugin/UrlTest.php
+++ b/test/Controller/Plugin/UrlTest.php
@@ -25,6 +25,9 @@ use Zend\Router\RouteMatch;
 use Zend\Router\SimpleRouteStack;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
 
+/**
+ * @covers \Zend\Mvc\Controller\Plugin\Url
+ */
 class UrlTest extends TestCase
 {
     public function setUp() : void

--- a/test/Controller/PluginManagerTest.php
+++ b/test/Controller/PluginManagerTest.php
@@ -16,6 +16,9 @@ use Zend\ServiceManager\ServiceManager;
 use ZendTest\Mvc\Controller\Plugin\TestAsset\SamplePlugin;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
 
+/**
+ * @covers \Zend\Mvc\Controller\PluginManager
+ */
 class PluginManagerTest extends TestCase
 {
     public function testPluginManagerInjectsControllerInPlugin()

--- a/test/Controller/RestfulControllerTest.php
+++ b/test/Controller/RestfulControllerTest.php
@@ -35,6 +35,9 @@ use function method_exists;
 use function sort;
 use function uniqid;
 
+/**
+ * @covers \Zend\Mvc\Controller\AbstractRestfulController
+ */
 class RestfulControllerTest extends TestCase
 {
     public $controller;

--- a/test/DispatchListenerTest.php
+++ b/test/DispatchListenerTest.php
@@ -25,6 +25,9 @@ use Zend\View\Model\ModelInterface;
 
 use function var_export;
 
+/**
+ * @covers \Zend\Mvc\DispatchListener
+ */
 class DispatchListenerTest extends TestCase
 {
     public function createMvcEvent($controllerMatched)

--- a/test/Exception/InvalidMiddlewareExceptionTest.php
+++ b/test/Exception/InvalidMiddlewareExceptionTest.php
@@ -14,6 +14,9 @@ use Zend\Mvc\Exception\InvalidMiddlewareException;
 
 use function uniqid;
 
+/**
+ * @covers \Zend\Mvc\Exception\InvalidMiddlewareException
+ */
 final class InvalidMiddlewareExceptionTest extends TestCase
 {
     public function testFromMiddlewareName()

--- a/test/Exception/ReachedFinalHandlerExceptionTest.php
+++ b/test/Exception/ReachedFinalHandlerExceptionTest.php
@@ -12,6 +12,9 @@ namespace ZendTest\Mvc;
 use PHPUnit\Framework\TestCase;
 use Zend\Mvc\Exception\ReachedFinalHandlerException;
 
+/**
+ * @covers \Zend\Mvc\Exception\ReachedFinalHandlerException
+ */
 final class ReachedFinalHandlerExceptionTest extends TestCase
 {
     public function testFromNothing()

--- a/test/MiddlewareListenerTest.php
+++ b/test/MiddlewareListenerTest.php
@@ -38,6 +38,9 @@ use function sprintf;
 use function uniqid;
 use function var_export;
 
+/**
+ * @covers \Zend\Mvc\MiddlewareListener
+ */
 class MiddlewareListenerTest extends TestCase
 {
     /** @var ObjectProphecy */

--- a/test/ModuleRouteListenerTest.php
+++ b/test/ModuleRouteListenerTest.php
@@ -18,6 +18,9 @@ use Zend\Mvc\RouteListener;
 use Zend\Router;
 use Zend\Router\RouteMatch;
 
+/**
+ * @covers \Zend\Mvc\ModuleRouteListener
+ */
 class ModuleRouteListenerTest extends TestCase
 {
     public function setUp() : void

--- a/test/ResponseSender/AbstractResponseSenderTest.php
+++ b/test/ResponseSender/AbstractResponseSenderTest.php
@@ -23,6 +23,9 @@ use function phpversion;
 use function version_compare;
 use function xdebug_get_headers;
 
+/**
+ * @covers \Zend\Mvc\ResponseSender\AbstractResponseSender
+ */
 class AbstractResponseSenderTest extends TestCase
 {
     /**

--- a/test/ResponseSender/PhpEnvironmentResponseSenderTest.php
+++ b/test/ResponseSender/PhpEnvironmentResponseSenderTest.php
@@ -18,6 +18,9 @@ use Zend\Stdlib\ResponseInterface;
 use function ob_get_clean;
 use function ob_start;
 
+/**
+ * @covers \Zend\Mvc\ResponseSender\PhpEnvironmentResponseSender
+ */
 class PhpEnvironmentResponseSenderTest extends TestCase
 {
     public function testSendResponseIgnoresInvalidResponseTypes()

--- a/test/ResponseSender/SendResponseEventTest.php
+++ b/test/ResponseSender/SendResponseEventTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 use Zend\Mvc\ResponseSender\SendResponseEvent;
 use Zend\Stdlib\ResponseInterface;
 
+/**
+ * @covers \Zend\Mvc\ResponseSender\SendResponseEvent
+ */
 class SendResponseEventTest extends TestCase
 {
     public function testContentSentAndHeadersSent()

--- a/test/ResponseSender/SimpleStreamResponseSenderTest.php
+++ b/test/ResponseSender/SimpleStreamResponseSenderTest.php
@@ -20,6 +20,9 @@ use function fopen;
 use function ob_get_clean;
 use function ob_start;
 
+/**
+ * @covers \Zend\Mvc\ResponseSender\SimpleStreamResponseSender
+ */
 class SimpleStreamResponseSenderTest extends TestCase
 {
     public function testSendResponseIgnoresInvalidResponseTypes()

--- a/test/SendResponseListenerTest.php
+++ b/test/SendResponseListenerTest.php
@@ -17,6 +17,9 @@ use Zend\Stdlib\ResponseInterface;
 
 use function array_values;
 
+/**
+ * @covers \Zend\Mvc\SendResponseListener
+ */
 class SendResponseListenerTest extends TestCase
 {
     public function testEventManagerIdentifiers()

--- a/test/View/CreateViewModelListenerTest.php
+++ b/test/View/CreateViewModelListenerTest.php
@@ -20,6 +20,9 @@ use Zend\View\Model\ViewModel;
 use function count;
 use function gettype;
 
+/**
+ * @covers \Zend\Mvc\View\Http\CreateViewModelListener
+ */
 class CreateViewModelListenerTest extends TestCase
 {
     use EventListenerIntrospectionTrait;

--- a/test/View/DefaultRendereringStrategyTest.php
+++ b/test/View/DefaultRendereringStrategyTest.php
@@ -29,6 +29,9 @@ use Zend\View\View;
 use function json_encode;
 use function sprintf;
 
+/**
+ * @covers \Zend\Mvc\View\Http\DefaultRenderingStrategy
+ */
 class DefaultRendereringStrategyTest extends TestCase
 {
     use EventListenerIntrospectionTrait;

--- a/test/View/ExceptionStrategyTest.php
+++ b/test/View/ExceptionStrategyTest.php
@@ -21,6 +21,9 @@ use Zend\View\Model\ViewModel;
 
 use function count;
 
+/**
+ * @covers \Zend\Mvc\View\Http\ExceptionStrategy
+ */
 class ExceptionStrategyTest extends TestCase
 {
     use EventListenerIntrospectionTrait;

--- a/test/View/InjectTemplateListenerTest.php
+++ b/test/View/InjectTemplateListenerTest.php
@@ -21,6 +21,9 @@ use ZendTest\Mvc\Controller\TestAsset\SampleController;
 
 use function count;
 
+/**
+ * @covers \Zend\Mvc\View\Http\InjectTemplateListener
+ */
 class InjectTemplateListenerTest extends TestCase
 {
     use EventListenerIntrospectionTrait;

--- a/test/View/InjectViewModelListenerTest.php
+++ b/test/View/InjectViewModelListenerTest.php
@@ -19,6 +19,9 @@ use Zend\View\Model\ViewModel;
 
 use function count;
 
+/**
+ * @covers \Zend\Mvc\View\Http\InjectViewModelListener
+ */
 class InjectViewModelListenerTest extends TestCase
 {
     use EventListenerIntrospectionTrait;

--- a/test/View/RouteNotFoundStrategyTest.php
+++ b/test/View/RouteNotFoundStrategyTest.php
@@ -20,6 +20,9 @@ use Zend\Mvc\View\Http\RouteNotFoundStrategy;
 use Zend\View\Model\ModelInterface;
 use Zend\View\Model\ViewModel;
 
+/**
+ * @covers \Zend\Mvc\View\Http\RouteNotFoundStrategy
+ */
 class RouteNotFoundStrategyTest extends TestCase
 {
     use EventListenerIntrospectionTrait;


### PR DESCRIPTION
This PR forces coverage annotation and adds `@covers` to tests. That will massively drop coverage and uncover code that needs more dedicated testing. 

- [ ] Are you fixing a bug?

- [ ] Are you creating a new feature?

- [x] Is this related to quality assurance?
  This PR forces covers annotations to reduce accidental coverage and improve overall value of coverage metric. Any future work can rely on it to additionally improve tests for affected code. 

- [ ] Is this related to documentation?
