### PR TITLE
Adds missing language strings to unreadable code examples

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -44,7 +44,7 @@ response.
 
 The basic application structure follows:
 
-```
+```bash
 application_root/
     config/
         application.config.php
@@ -93,7 +93,7 @@ number of tasks.
 
 The recommended module structure follows:
 
-```
+```bash
 module_root<named-after-module-namespace>/
     Module.php
     autoload_classmap.php
@@ -367,7 +367,6 @@ Remember the `application.config.php` from earlier? We're going to provide some
 configuration.
 
 ```php
-<?php
 // config/application.config.php
 return array(
     'modules' => array(


### PR DESCRIPTION
Two code examples in the introduction are unreadable:

* https://docs.zendframework.com/zend-mvc/intro/#basic-application-structure
* https://docs.zendframework.com/zend-mvc/intro/#basic-module-structure


