### PR TITLE
Fixes wrong headline in migration guide

### DIFF
--- a/docs/book/migration/to-v2-7.md
+++ b/docs/book/migration/to-v2-7.md
@@ -1,4 +1,4 @@
-## Upgrading to 2.7
+# Upgrading to 2.7
 
 ## Middleware
 


### PR DESCRIPTION
We need `h1` instead of `h2`:

https://docs.zendframework.com/zend-mvc/migration/to-v2-7/