### PR TITLE
Updated AbstractActionController::indexAction return type to reflect real usage

### DIFF
--- a/src/Controller/AbstractActionController.php
+++ b/src/Controller/AbstractActionController.php
@@ -9,7 +9,8 @@ namespace Zend\Mvc\Controller;
 
 use Zend\Mvc\Exception;
 use Zend\Mvc\MvcEvent;
-use Zend\Stdlib\ResponseInterface as Response;
+use Zend\Stdlib\ResponseInterface;
+use Zend\View\Model\ModelInterface as ViewModelInterface;
 use Zend\View\Model\ViewModel;
 
 /**
@@ -25,7 +26,7 @@ abstract class AbstractActionController extends AbstractController
     /**
      * Default action if none provided
      *
-     * @return null|array|ViewModel|Response
+     * @return null|array|ViewModelInterface|ResponseInterface
      */
     public function indexAction()
     {

--- a/src/Controller/AbstractActionController.php
+++ b/src/Controller/AbstractActionController.php
@@ -9,6 +9,7 @@ namespace Zend\Mvc\Controller;
 
 use Zend\Mvc\Exception;
 use Zend\Mvc\MvcEvent;
+use Zend\Stdlib\ResponseInterface as Response;
 use Zend\View\Model\ViewModel;
 
 /**
@@ -24,7 +25,7 @@ abstract class AbstractActionController extends AbstractController
     /**
      * Default action if none provided
      *
-     * @return ViewModel
+     * @return null|array|ViewModel|Response
      */
     public function indexAction()
     {


### PR DESCRIPTION
- [x] Is this related to quality assurance?

When running static analysis against a simple userland controller like:
```php
class MyController extends AbstractActionController
{
    public function indexAction()
    {
        return ['posts' => ['foo', 'bar']];
    }
}
```
That do **NOT** provide the return type, neither with PHP 7.1 return type nor via DocBlock, tools like PHPstan use inherited docs and report:
```
Method MyController::indexAction() should return Zend\View\Model\ViewModel but returns array.
```
Of course users should add return types, but it would result in requiring a massive code update without real benefits, since the default behavior of Zend\Mvc framework is to allow:

1. `null` from [`\Zend\Mvc\View\Http\CreateViewModelListener::createViewModelFromNull`](https://github.com/zendframework/zend-mvc/blob/9f092ff24945f208047d99dff81f67de8862b5f4/src/View/Http/CreateViewModelListener.php#L50) listener
1. `array` from [`\Zend\Mvc\View\Http\CreateViewModelListener::createViewModelFromArray`](https://github.com/zendframework/zend-mvc/blob/9f092ff24945f208047d99dff81f67de8862b5f4/src/View/Http/CreateViewModelListener.php#L33) listener
1. `ViewModel` from [`\Zend\Mvc\View\Http\DefaultRenderingStrategy::render`](https://github.com/zendframework/zend-mvc/blob/9f092ff24945f208047d99dff81f67de8862b5f4/src/View/Http/DefaultRenderingStrategy.php#L81) listener
1. `ResponseInterface` from [`\Zend\Mvc\SendResponseListener::sendResponse`](https://github.com/zendframework/zend-mvc/blob/9f092ff24945f208047d99dff81f67de8862b5f4/src/SendResponseListener.php#L83) listener

This change only applies to `indexAction` since I guess its usage is widespread: `notFoundAction` is untouched as users that override it are, IMHO, already advanced ones.

Ping @Ocramius you type lover :heart: 

Reference: https://github.com/Slamdunk/phpstan-zend-framework/issues/5