### PR TITLE
fixed SimpleStreamResponseSender ignored defined content length

### DIFF
--- a/src/ResponseSender/SimpleStreamResponseSender.php
+++ b/src/ResponseSender/SimpleStreamResponseSender.php
@@ -22,9 +22,17 @@ class SimpleStreamResponseSender extends AbstractResponseSender
         if ($event->contentSent()) {
             return $this;
         }
+
         $response = $event->getResponse();
         $stream   = $response->getStream();
-        fpassthru($stream);
+        $length   = $response->getContentLength();
+
+        if ($length) {
+            stream_copy_to_stream($stream, fopen('php://output', 'wb'), $length);
+        } else {
+            fpassthru($stream);
+        }
+
         $event->setContentSent();
     }
 

--- a/test/ResponseSender/SimpleStreamResponseSenderTest.php
+++ b/test/ResponseSender/SimpleStreamResponseSenderTest.php
@@ -45,6 +45,26 @@ class SimpleStreamResponseSenderTest extends TestCase
         $this->assertEquals('', $body);
     }
 
+    public function testSendResponseContentLength()
+    {
+        $file = fopen(__DIR__ . '/TestAsset/sample-stream-file.txt', 'rb');
+        $mockResponse = $this->createMock(Response\Stream::class);
+        $mockResponse->expects($this->once())->method('getStream')->will($this->returnValue($file));
+        $mockResponse->expects($this->once())->method('getContentLength')->will($this->returnValue(12));
+        $mockSendResponseEvent = $this->getSendResponseEventMock($mockResponse);
+        $responseSender = new SimpleStreamResponseSender();
+        ob_start();
+        $responseSender($mockSendResponseEvent);
+        $body = ob_get_clean();
+        $expected = file_get_contents(__DIR__ . '/TestAsset/sample-stream-file.txt');
+        $this->assertEquals(substr($expected, 0, 12), $body);
+
+        ob_start();
+        $responseSender($mockSendResponseEvent);
+        $body = ob_get_clean();
+        $this->assertEquals('', $body);
+    }
+
     protected function getSendResponseEventMock($response)
     {
         $mockSendResponseEvent = $this->getMockBuilder(ResponseSender\SendResponseEvent::class)


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

We are using the stream HTTP response to directly stream file content from S3 to clients.
As we are dealing with video files we are using the the `Range`/`Content-Range` headers to allow clients to download specific parts of files.

To be able to do so we use the `Zend\Http\Response\Stream::setContentLength` method together with `fseek` to define the parts of the file to send.

Where `Stream::readStream` is dealing with the content length it's not handled in `SimpleStreamResponseSender` and the stream gets send until EOF.

To fix that this PR uses `stream_copy_to_stream` to `php://output` instead of `fpassthru` if a content length has been defined.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
